### PR TITLE
Event times getter

### DIFF
--- a/ephios/event_management/models.py
+++ b/ephios/event_management/models.py
@@ -64,13 +64,11 @@ class Event(Model):
         verbose_name_plural = _("events")
         permissions = [("view_past_event", _("Can view past events"))]
 
-    @property
-    def start_time(self):
+    def get_start_time(self):
         if (first_shift := self.shifts.order_by("start_time").first()) is not None:
             return first_shift.start_time
 
-    @property
-    def end_time(self):
+    def get_end_time(self):
         if (last_shift := self.shifts.order_by("end_time").last()) is not None:
             return last_shift.end_time
 

--- a/ephios/event_management/pdf.py
+++ b/ephios/event_management/pdf.py
@@ -103,8 +103,8 @@ class MultipleShiftEventExporter(BasePDFExporter):
         ]
 
         tz = pytz.timezone(settings.TIME_ZONE)
-        start_time = self.event.start_time.astimezone(tz)
-        end_time = self.event.end_time.astimezone(tz)
+        start_time = self.event.get_start_time().astimezone(tz)
+        end_time = self.event.get_end_time().astimezone(tz)
         end_date = (
             f"- {formats.date_format(end_time, 'l')}, {formats.date_format(end_time, 'SHORT_DATE_FORMAT')}"
             if end_time.date() > start_time.date()

--- a/ephios/event_management/templates/event_management/event_archive.html
+++ b/ephios/event_management/templates/event_management/event_archive.html
@@ -26,8 +26,8 @@
             <tr>
                 <td>{{ event.title }}</td>
                 <td>{{ event.location }}</td>
-                <td>{{ event.start_time | date:"d.m.Y" }}</td>
-                <td>{{ event.end_time | date:"d.m.Y" }}</td>
+                <td>{{ event.start_time|date:"SHORT_DATE_FORMAT" }}</td>
+                <td>{{ event.end_time|date:"SHORT_DATE_FORMAT" }}</td>
                 <td><a class="btn btn-primary" href="{% url "event_management:event_detail" event.id %}"><span
                         class="fa fa-eye"></span> <span class="d-none d-md-inline">{% trans "Show" %}</span></a></td>
             </tr>

--- a/ephios/event_management/templates/event_management/event_detail.html
+++ b/ephios/event_management/templates/event_management/event_detail.html
@@ -10,7 +10,7 @@
 {% block content %}
     {% get_obj_perms request.user for event as "event_perms" %}
     {% if not event.active %}
-        {% if event.shifts.all %}
+        {% if event.shifts.exists %}
             {% trans "This event has not been saved! If you are done editing the event, you can save it." as not_active_error %}
             {% trans "Save" as save_trans %}
             <form method='POST' class='form' action='{% url "event_management:event_activate" event.pk %}'>

--- a/ephios/event_management/templates/event_management/event_list.html
+++ b/ephios/event_management/templates/event_management/event_list.html
@@ -30,8 +30,8 @@
             <tr>
                 <td>{{ event.title }}</td>
                 <td>{{ event.location }}</td>
-                <td>{{ event.start_time | date:"d.m.Y" }}</td>
-                <td>{{ event.end_time | date:"d.m.Y" }}</td>
+                <td>{{ event.start_time|date:"SHORT_DATE_FORMAT" }}</td>
+                <td>{{ event.end_time|date:"SHORT_DATE_FORMAT" }}</td>
                 <td><a class="btn btn-primary" href="{% url "event_management:event_detail" event.id %}"><span
                         class="fa fa-eye"></span> <span class="d-none d-md-inline">{% trans "Show" %}</span></a></td>
             </tr>

--- a/ephios/templates/base.html
+++ b/ephios/templates/base.html
@@ -110,7 +110,7 @@
                     <a href="{{ url }}">{{ label }}</a> ·
                 {% endfor %}
                 <span class="text-muted">
-                    {% blocktranslate with brand='<a href="https://ephios.de/" target="_blank">ephios</a>' %}
+                    {% blocktranslate with brand='<a href="https://ephios.de/" rel="noreferrer" target="_blank">ephios</a>' %}
                         powered by {{ brand }}
                     {% endblocktranslate %}
                     <samp>{{ ephios_version|default_if_none:"" }}</samp>


### PR DESCRIPTION
Ok hear me out on this one. This is about performance. When we have 100 events in the list, we don't want to make queries for every single one of them. But that's what has been happening with start and end times. I now changed start and end time on event to be a getter to make more clear that it does a query. (It was only used in the multi shift pdf export afais).

Then I just used annotate for the two list views.