### PR TITLE
Assign event view permissions to participating users

### DIFF
--- a/ephios/event_management/forms.py
+++ b/ephios/event_management/forms.py
@@ -11,7 +11,7 @@ from guardian.shortcuts import assign_perm, get_objects_for_user, get_users_with
 from recurrence.forms import RecurrenceField
 
 from ephios.event_management import signup
-from ephios.event_management.models import Event, Shift
+from ephios.event_management.models import Event, LocalParticipation, Shift
 from ephios.extra.permissions import get_groups_with_perms
 from ephios.extra.widgets import CustomDateInput, CustomTimeInput
 from ephios.user_management.models import UserProfile
@@ -105,6 +105,15 @@ class EventForm(ModelForm):
         assign_perm("change_event", self.cleaned_data["responsible_groups"], event)
         assign_perm("view_event", self.cleaned_data["responsible_users"], event)
         assign_perm("change_event", self.cleaned_data["responsible_users"], event)
+
+        # assign view permissions to users that already have some sort of participation for the event
+        # (-> they saw and interacted with it)
+        participating_users = UserProfile.objects.filter(
+            pk__in=LocalParticipation.objects.filter(shift_id__in=event.shifts.all()).values_list(
+                "user", flat=True
+            )
+        )
+        assign_perm("view_event", participating_users, event)
 
         return event
 

--- a/ephios/event_management/forms.py
+++ b/ephios/event_management/forms.py
@@ -22,7 +22,9 @@ class EventForm(ModelForm):
     visible_for = ModelMultipleChoiceField(
         queryset=Group.objects.none(),
         label=_("Visible for"),
-        help_text=_("Select groups which the event shall be visible for."),
+        help_text=_(
+            "Select groups which the event shall be visible for. Regardless, the event will be visible for users that already signed up."
+        ),
         widget=Select2MultipleWidget,
         required=False,
     )

--- a/ephios/event_management/models.py
+++ b/ephios/event_management/models.py
@@ -153,10 +153,8 @@ class Shift(Model):
         return AbstractParticipation.objects.filter(shift=self)
 
     def get_participants(self, with_state_in=frozenset({AbstractParticipation.States.CONFIRMED})):
-        yield from (
-            participation.participant
-            for participation in self.participations.filter(state__in=with_state_in)
-        )
+        for participation in self.participations.filter(state__in=with_state_in):
+            yield participation.participant
 
     def __str__(self):
         return f"{self.event.title} ({self.get_start_end_time_display()})"


### PR DESCRIPTION
Editing the `visible_for` on events after people already signed up for shifts is a complicated situation. 
To avoid confusion about why an event became invisible, I propose to force view permissions for participating users.

For now, I opted for allowing *any* state for `LocalParticipation`, which is very much debatable:

* confirmed users should always see the event, as they are involved in it (calendar, date info, notifications etc...)
* requested users should be able to see that they requested a participation. I'd say the same goes for declined and rejected
* We *could* remove the `GETTING_DISPATCHED` state, though I did not bother, since this state probably doesn't exist when editing the event.