### PR TITLE
display timezone errors in disposition

### DIFF
--- a/ephios/core/signup/methods.py
+++ b/ephios/core/signup/methods.py
@@ -134,11 +134,12 @@ class BaseParticipationForm(forms.ModelForm):
 
     def clean(self):
         cleaned_data = super().clean()
-        start = cleaned_data["individual_start_time"] or self.shift.start_time
-        end = cleaned_data["individual_end_time"] or self.shift.end_time
-        if end < start:
-            self.add_error("individual_end_time", _("End time must not be before start time."))
-        return cleaned_data
+        if not self.errors:
+            start = cleaned_data["individual_start_time"] or self.shift.start_time
+            end = cleaned_data["individual_end_time"] or self.shift.end_time
+            if end < start:
+                self.add_error("individual_end_time", _("End time must not be before start time."))
+            return cleaned_data
 
     class Meta:
         model = AbstractParticipation

--- a/ephios/core/templates/core/disposition/fragment_participation.html
+++ b/ephios/core/templates/core/disposition/fragment_participation.html
@@ -50,7 +50,7 @@
             {% endif %}
         </div>
     </div>
-    <div class="collapse mt-3 do-not-drag card bg-light" data-bs-parent="#participations-form"
+    <div class="collapse {% if form.errors %}show{% endif %} mt-3 do-not-drag card bg-light" data-bs-parent="#participations-form"
          id="participation-collapse-{{ form.instance.id }}">
         <div class="card-body">
             {{ form.individual_start_time|as_crispy_field }}

--- a/ephios/extra/widgets.py
+++ b/ephios/extra/widgets.py
@@ -1,4 +1,4 @@
-from django.forms import DateInput, MultiWidget, SplitDateTimeWidget, TimeInput
+from django.forms import DateInput, MultiWidget, TimeInput
 from django.forms.utils import to_current_timezone
 from django.forms.widgets import Input
 
@@ -13,10 +13,6 @@ class CustomDateInput(DateInput):
 
 class CustomTimeInput(TimeInput):
     template_name = "extra/widgets/custom_time_input.html"
-
-
-class CustomSplitDateTimeInput(SplitDateTimeWidget):
-    pass
 
 
 class CustomSplitDateTimeWidget(MultiWidget):


### PR DESCRIPTION
makes sure that the errors caused by #417 are properly displayed in the disposition form and are not causing HTTP 500 anymore