### PR TITLE
fix mobile layout for workinghour views

### DIFF
--- a/ephios/core/templates/core/userprofile_workinghours.html
+++ b/ephios/core/templates/core/userprofile_workinghours.html
@@ -35,7 +35,7 @@
                         <td>{{ item.date|date:"SHORT_DATE_FORMAT" }}</td>
                         <td class="break-word">{{ item.reason }}</td>
                         <td class="text-nowrap">{{ item.duration|timedelta_in_hours }} <span class="d-none d-md-inline"> {% translate "hours" %}</span></td>
-                        <td class="d-flex">
+                        <td class="whitespace-nowrap">
                             {% if can_grant %}
                                 {% if item.type == "event" %}
                                     <a class="btn btn-secondary btn-sm text-nowrap" href="{% url "core:event_detail" item.origin_id "none" %}"><span class="fa fa-eye"></span> <span class="d-none d-md-inline">{% trans "View event" %}</span></a>

--- a/ephios/core/templates/core/userprofile_workinghours.html
+++ b/ephios/core/templates/core/userprofile_workinghours.html
@@ -24,7 +24,7 @@
             <tr>
                 <th>{% trans "Date" %}</th>
                 <th>{% trans "Reason" %}</th>
-                <th class="d-none d-lg-table-cell">{% trans "Hours" %}</th>
+                <th>{% trans "Hours" %}</th>
                 <th>{% trans "Action" %}</th>
             </tr>
             </thead>
@@ -34,8 +34,8 @@
                     <tr>
                         <td>{{ item.date|date:"SHORT_DATE_FORMAT" }}</td>
                         <td class="break-word">{{ item.reason }}</td>
-                        <td class="text-nowrap">{{ item.duration|timedelta_in_hours }} {% translate "hours" %}</td>
-                        <td>
+                        <td class="text-nowrap">{{ item.duration|timedelta_in_hours }} <span class="d-none d-md-inline"> {% translate "hours" %}</span></td>
+                        <td class="d-flex">
                             {% if can_grant %}
                                 {% if item.type == "event" %}
                                     <a class="btn btn-secondary btn-sm text-nowrap" href="{% url "core:event_detail" item.origin_id "none" %}"><span class="fa fa-eye"></span> <span class="d-none d-md-inline">{% trans "View event" %}</span></a>
@@ -50,7 +50,7 @@
                 <tr>
                     <td><b>{% translate "Total" %}</b></td>
                     <td></td>
-                    <td>{{ workhour_items.0|timedelta_in_hours }} {% translate "hours" %}</td>
+                    <td>{{ workhour_items.0|timedelta_in_hours }}<span class="d-none d-md-inline"> {% translate "hours" %}</span></td>
                     <td></td>
                 </tr>
             {% endwith %}

--- a/ephios/core/templates/core/workinghours_list.html
+++ b/ephios/core/templates/core/workinghours_list.html
@@ -29,7 +29,7 @@
         <tr>
             <th>{% translate "Last name" %}</th>
             <th>{% translate "First name" %}</th>
-            <th class="d-none d-lg-table-cell">{% translate "Working hours" %}</th>
+            <th>{% translate "Hours" %}</th>
             <th>{% translate "Action" %}</th>
         </tr>
         </thead>
@@ -38,7 +38,7 @@
             <tr>
                 <td>{{ user.last_name }}</td>
                 <td>{{ user.first_name }}</td>
-                <td class="d-none d-lg-table-cell">{{ user.hours|floatformat:2 }}</td>
+                <td>{{ user.hours|floatformat:2 }}</td>
                 <td class="d-flex">
                     <a class="btn btn-secondary btn-sm text-nowrap"
                        href="{% url "core:workinghours_detail" user.pk %}"><span
@@ -53,7 +53,6 @@
                         {% endif %}
                     {% endwith %}
                 </td>
-                <td></td>
             </tr>
         {% empty %}
             <tr>

--- a/ephios/static/ephios/scss/ephios_custom.scss
+++ b/ephios/static/ephios/scss/ephios_custom.scss
@@ -219,3 +219,7 @@ a.badge {
 .invalid-feedback {
   display: block;
 }
+
+.whitespace-nowrap {
+  white-space: nowrap;
+}

--- a/tests/core/test_workinghours.py
+++ b/tests/core/test_workinghours.py
@@ -11,14 +11,14 @@ class TestWorkingHours:
     def test_own_workinghours_without_hours(self, django_app, volunteer):
         response = django_app.get(reverse("core:workinghours_own"), user=volunteer)
         assert response.status_code == 200
-        assert response.html.find(text=f"{floatformat(0, arg=2)} hours")
+        assert response.html.find(text=f"{floatformat(0, arg=2)}")
 
     def test_own_workinghours(self, django_app, volunteer, workinghours):
         response = django_app.get(reverse("core:workinghours_own"), user=volunteer)
         assert response.html.find(text=workinghours[0].reason)
         assert response.html.find(text=workinghours[1].reason)
         total_hours = workinghours[0].hours + workinghours[1].hours
-        assert response.html.find(text=f"{floatformat(total_hours, arg=2)} hours")
+        assert response.html.find(text=f"{floatformat(total_hours, arg=2)}")
 
     def test_workinghours_rounding(self, django_app, volunteer, event):
         from ephios.core.models import AbstractParticipation, LocalParticipation


### PR DESCRIPTION
I can't get the buttons to use the full height of the row while staying on the same line instead of being on top of each other. @felixrindt can you do some CSS magic here?
![grafik](https://user-images.githubusercontent.com/12702135/209341646-44b3a189-84a0-41cd-9a6c-26ffe776b7b4.png)
