### PR TITLE
Remove unused fields from special case signup methods

### DIFF
--- a/ephios/plugins/basesignup/signup/common.py
+++ b/ephios/plugins/basesignup/signup/common.py
@@ -1,6 +1,8 @@
 import typing
 
 from django import forms
+from django.contrib import messages
+from django.shortcuts import redirect
 from django.utils.translation import gettext_lazy as _
 from django_select2.forms import Select2MultipleWidget
 from dynamic_preferences.registries import global_preferences_registry
@@ -8,6 +10,7 @@ from dynamic_preferences.registries import global_preferences_registry
 from ephios.core.models import AbstractParticipation, Qualification
 from ephios.core.signup.methods import (
     BaseSignupMethod,
+    BaseSignupView,
     ParticipantUnfitError,
     SignupDisallowedError,
 )
@@ -156,3 +159,11 @@ class QualificationMinMaxBaseSignupMethod(
                 rendered_count - len(participation_info)
             )
         return participation_info
+
+
+class NoSignupSignupView(BaseSignupView):
+    def get(self, request, *args, **kwargs):
+        messages.error(self.request, _("This action is not allowed."))
+        return redirect(self.participant.reverse_event_detail(self.shift.event))
+
+    post = get

--- a/ephios/plugins/basesignup/signup/coupled_signup.py
+++ b/ephios/plugins/basesignup/signup/coupled_signup.py
@@ -21,7 +21,7 @@ class CoupledSignupMethod(RenderParticipationPillsShiftStateMixin, BaseSignupMet
 
     @property
     def configuration_form_class(self):
-        class ConfigurationForm(super().configuration_form_class):
+        class ConfigurationForm(forms.Form):
             leader_shift_id = forms.ModelChoiceField(
                 label=_("shift to mirror participation from"),
                 required=True,

--- a/ephios/plugins/basesignup/signup/coupled_signup.py
+++ b/ephios/plugins/basesignup/signup/coupled_signup.py
@@ -10,7 +10,10 @@ from django.utils.translation import gettext_lazy as _
 
 from ephios.core.models import AbstractParticipation, Shift
 from ephios.core.signup.methods import ActionDisallowedError, BaseSignupMethod, SignupStats
-from ephios.plugins.basesignup.signup.common import RenderParticipationPillsShiftStateMixin
+from ephios.plugins.basesignup.signup.common import (
+    NoSignupSignupView,
+    RenderParticipationPillsShiftStateMixin,
+)
 
 
 class CoupledSignupMethod(RenderParticipationPillsShiftStateMixin, BaseSignupMethod):
@@ -18,6 +21,7 @@ class CoupledSignupMethod(RenderParticipationPillsShiftStateMixin, BaseSignupMet
     verbose_name = _("coupled to another shift")
     description = _("""This method mirrors signup from another shift.""")
     uses_requested_state = True
+    signup_view_class = NoSignupSignupView
 
     @property
     def configuration_form_class(self):

--- a/ephios/plugins/basesignup/signup/no_selfservice.py
+++ b/ephios/plugins/basesignup/signup/no_selfservice.py
@@ -6,22 +6,20 @@ from ephios.core.signup.methods import ActionDisallowedError, BaseSignupMethod
 from ephios.plugins.basesignup.signup.common import RenderParticipationPillsShiftStateMixin
 
 
+class NoSelfserviceConfigurationForm(forms.Form):
+    no_selfservice_explanation = forms.CharField(
+        label=_("Explanation"),
+        required=False,
+        initial="",
+    )
+
+
 class NoSelfserviceSignupMethod(RenderParticipationPillsShiftStateMixin, BaseSignupMethod):
     slug = "no_selfservice"
     verbose_name = _("No Signup (only disposition)")
     description = _("""This method allows no signup by users.""")
     uses_requested_state = False
-
-    @property
-    def configuration_form_class(self):
-        class ConfigurationForm(super().configuration_form_class):
-            no_selfservice_explanation = forms.CharField(
-                label=_("Explanation"),
-                required=False,
-                initial="",
-            )
-
-        return ConfigurationForm
+    configuration_form_class = NoSelfserviceConfigurationForm
 
     def _configure_participation(
         self, participation: AbstractParticipation, **kwargs

--- a/ephios/plugins/basesignup/signup/no_selfservice.py
+++ b/ephios/plugins/basesignup/signup/no_selfservice.py
@@ -3,7 +3,10 @@ from django.utils.translation import gettext_lazy as _
 
 from ephios.core.models import AbstractParticipation
 from ephios.core.signup.methods import ActionDisallowedError, BaseSignupMethod
-from ephios.plugins.basesignup.signup.common import RenderParticipationPillsShiftStateMixin
+from ephios.plugins.basesignup.signup.common import (
+    NoSignupSignupView,
+    RenderParticipationPillsShiftStateMixin,
+)
 
 
 class NoSelfserviceConfigurationForm(forms.Form):
@@ -20,6 +23,7 @@ class NoSelfserviceSignupMethod(RenderParticipationPillsShiftStateMixin, BaseSig
     description = _("""This method allows no signup by users.""")
     uses_requested_state = False
     configuration_form_class = NoSelfserviceConfigurationForm
+    signup_view_class = NoSignupSignupView
 
     def _configure_participation(
         self, participation: AbstractParticipation, **kwargs

--- a/tests/plugins/basesignup/test_no_selfservice.py
+++ b/tests/plugins/basesignup/test_no_selfservice.py
@@ -18,10 +18,4 @@ def test_no_selfservice_renders(django_app, volunteer, event, no_selfservice_shi
 
 def test_no_selfservice_does_not_allow_signup(django_app, volunteer, event, no_selfservice_shift):
     event_detail = django_app.get(event.get_absolute_url(), user=volunteer)
-    # django webtest would ignore a `signup_choice` on the event_detail view, so we just get the default sign up view
-    signup_view = event_detail.form.submit()
-    # from there though, signup will not be possible
-    assert (
-        "This action is not allowed"
-        in signup_view.form.submit(name="signup_choice", value="sign_up").follow()
-    )
+    assert "This action is not allowed" in event_detail.form.submit().follow()


### PR DESCRIPTION
I don't know why we did it this way last time. Maybe an error during refactoring. In my opinion, we really don't need the base fields for coupled and no-selfservice signup:

`minimum_age`, `signup_until`, `user_can_decline_confirmed`, `user_can_customize_signup_times`