### PR TITLE
Fix test warnings

### DIFF
--- a/ephios/core/signals.py
+++ b/ephios/core/signals.py
@@ -55,7 +55,7 @@ Receivers will receive a ``request`` keyword argument.
 event_forms = PluginSignal()
 """
 This signal is sent out to get a list of form instances to show on the event create and update views.
-You receive an `event` and `request` keyword arg you should use to create an instance of your form.
+You receive an `Optional[event]` and `request` keyword arg you should use to create an instance of your form.
 Subclass :py:class:`ephios.core.forms.events.BasePluginFormMixin` to customize the rendering behavior.
 If all forms are valid, `save` will be called on your form.
 """

--- a/ephios/core/views/event.py
+++ b/ephios/core/views/event.py
@@ -112,10 +112,10 @@ class EventFilterForm(forms.Form):
 
         date = fdata["date"]
         if fdata.get("direction", "from") == "from":
-            qs = qs.filter(end_time__gte=datetime.combine(date, time.min))
+            qs = qs.filter(end_time__gte=make_aware(datetime.combine(date, time.min)))
             qs = qs.order_by("start_time", "end_time")
         else:  # until
-            qs = qs.filter(start_time__lte=datetime.combine(date, time.max))
+            qs = qs.filter(start_time__lte=make_aware(datetime.combine(date, time.max)))
             qs = qs.order_by("-start_time", "-end_time")
 
         if event_types := fdata.get("types"):

--- a/ephios/extra/fields.py
+++ b/ephios/extra/fields.py
@@ -1,6 +1,7 @@
 import datetime
 
 from django import forms
+from django.forms.utils import from_current_timezone
 
 
 class EndOfDayDateTimeField(forms.DateTimeField):
@@ -13,8 +14,10 @@ class EndOfDayDateTimeField(forms.DateTimeField):
         result = super().to_python(value)
         if result is None:
             return result
-        return datetime.datetime.max.replace(
-            year=result.year,
-            month=result.month,
-            day=result.day,
+        return from_current_timezone(
+            datetime.datetime.max.replace(
+                year=result.year,
+                month=result.month,
+                day=result.day,
+            )
         )

--- a/ephios/plugins/eventautoqualification/forms.py
+++ b/ephios/plugins/eventautoqualification/forms.py
@@ -23,9 +23,9 @@ class EventAutoQualificationForm(BasePluginFormMixin, forms.ModelForm):
         self.event = event
         try:
             kwargs.setdefault(
-                "instance", EventAutoQualificationConfiguration.objects.get(event=self.event)
+                "instance", EventAutoQualificationConfiguration.objects.get(event_id=self.event.id)
             )
-        except EventAutoQualificationConfiguration.DoesNotExist:
+        except (AttributeError, EventAutoQualificationConfiguration.DoesNotExist):
             pass
 
         super().__init__(*args, **kwargs)

--- a/ephios/plugins/guests/forms.py
+++ b/ephios/plugins/guests/forms.py
@@ -18,9 +18,9 @@ class EventAllowGuestsForm(BasePluginFormMixin, forms.Form):
         self.request = kwargs.pop("request")
         super().__init__(*args, **kwargs)
         try:
-            self.instance = EventGuestShare.objects.get(event=self.event)
+            self.instance = EventGuestShare.objects.get(event_id=self.event.id)
             self.fields["link"].initial = self.instance.url
-        except EventGuestShare.DoesNotExist:
+        except (AttributeError, EventGuestShare.DoesNotExist):
             self.instance = EventGuestShare(event=self.event)
             del self.fields["link"]
             del self.fields["new_link"]

--- a/ephios/plugins/simpleresource/forms.py
+++ b/ephios/plugins/simpleresource/forms.py
@@ -21,8 +21,8 @@ class ResourceAllocationForm(BasePluginFormMixin, ModelForm):
         self.helper = FormHelper()
         self.helper.include_media = False
         try:
-            kwargs.setdefault("instance", ResourceAllocation.objects.get(shift=shift))
-        except ResourceAllocation.DoesNotExist:
+            kwargs.setdefault("instance", ResourceAllocation.objects.get(shift_id=shift.id))
+        except (AttributeError, ResourceAllocation.DoesNotExist):
             pass
         super().__init__(*args, **kwargs)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -91,6 +91,12 @@ max-line-length = "100"
 [tool.pytest.ini_options]
 DJANGO_SETTINGS_MODULE = "tests.settings"
 addopts = "--fail-on-template-vars"
+filterwarnings = [
+    # displaying naive datetime warnings as errors
+    # as seen in https://docs.djangoproject.com/en/4.1/topics/i18n/timezones/#code
+    # and https://docs.pytest.org/en/stable/how-to/capture-warnings.html#controlling-warnings
+    'error:DateTimeField .* received a naive datetime',
+]
 
 [build-system]
 requires = ["poetry-core>=1.0.0", "poetry-dynamic-versioning"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -96,6 +96,7 @@ filterwarnings = [
     # as seen in https://docs.djangoproject.com/en/4.1/topics/i18n/timezones/#code
     # and https://docs.pytest.org/en/stable/how-to/capture-warnings.html#controlling-warnings
     'error:DateTimeField .* received a naive datetime',
+    'error:Passing unsaved model instances to related filters',  # can be removed with Django5.0
 ]
 
 [build-system]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -126,10 +126,10 @@ def qualified_volunteer(qualifications, tz):
     QualificationGrant.objects.create(
         user=volunteer,
         qualification=qualifications.nfs,
-        expires=datetime(2064, 4, 1).astimezone(tz),
+        expires=datetime(2064, 4, 1, tzinfo=tz),
     )
     QualificationGrant.objects.create(
-        user=volunteer, qualification=qualifications.c, expires=datetime(2090, 4, 1).astimezone(tz)
+        user=volunteer, qualification=qualifications.c, expires=datetime(2090, 4, 1, tzinfo=tz)
     )
     QualificationGrant.objects.create(user=volunteer, qualification=qualifications.b, expires=None)
     return volunteer

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -203,9 +203,9 @@ def event(groups, service_event_type, planner, tz):
 
     Shift.objects.create(
         event=event,
-        meeting_time=datetime(2099, 6, 30, 7, 0).astimezone(tz),
-        start_time=datetime(2099, 6, 30, 8, 0).astimezone(tz),
-        end_time=datetime(2099, 6, 30, 20, 30).astimezone(tz),
+        meeting_time=datetime(2099, 6, 30, 7, 0, tzinfo=tz),
+        start_time=datetime(2099, 6, 30, 8, 0, tzinfo=tz),
+        end_time=datetime(2099, 6, 30, 20, 30, tzinfo=tz),
         signup_method_slug=RequestConfirmSignupMethod.slug,
         signup_configuration=dict(user_can_decline_confirmed=True),
     )
@@ -260,9 +260,9 @@ def event_to_next_day(groups, service_event_type, planner, tz):
 
     Shift.objects.create(
         event=event,
-        meeting_time=datetime(2099, 6, 30, 18, 0).astimezone(tz),
-        start_time=datetime(2099, 6, 30, 19, 0).astimezone(tz),
-        end_time=datetime(2099, 7, 1, 6, 0).astimezone(tz),
+        meeting_time=datetime(2099, 6, 30, 18, 0, tzinfo=tz),
+        start_time=datetime(2099, 6, 30, 19, 0, tzinfo=tz),
+        end_time=datetime(2099, 7, 1, 6, 0, tzinfo=tz),
         signup_method_slug=RequestConfirmSignupMethod.slug,
         signup_configuration={},
     )
@@ -285,18 +285,18 @@ def multi_shift_event(groups, service_event_type, planner, tz):
 
     Shift.objects.create(
         event=event,
-        meeting_time=datetime(2099, 6, 30, 7, 0).astimezone(tz),
-        start_time=datetime(2099, 6, 30, 8, 0).astimezone(tz),
-        end_time=datetime(2099, 6, 30, 20, 0).astimezone(tz),
+        meeting_time=datetime(2099, 6, 30, 7, 0, tzinfo=tz),
+        start_time=datetime(2099, 6, 30, 8, 0, tzinfo=tz),
+        end_time=datetime(2099, 6, 30, 20, 0, tzinfo=tz),
         signup_method_slug=RequestConfirmSignupMethod.slug,
         signup_configuration={},
     )
 
     Shift.objects.create(
         event=event,
-        meeting_time=datetime(2099, 7, 1, 7, 0).astimezone(tz),
-        start_time=datetime(2099, 7, 1, 8, 0).astimezone(tz),
-        end_time=datetime(2099, 7, 1, 20, 0).astimezone(tz),
+        meeting_time=datetime(2099, 7, 1, 7, 0, tzinfo=tz),
+        start_time=datetime(2099, 7, 1, 8, 0, tzinfo=tz),
+        end_time=datetime(2099, 7, 1, 20, 0, tzinfo=tz),
         signup_method_slug=RequestConfirmSignupMethod.slug,
         signup_configuration={},
     )
@@ -391,7 +391,7 @@ def qualifications_consequence(volunteer, qualifications, event, tz):
         user=volunteer,
         shift=event.shifts.first(),
         qualification=qualifications.nfs,
-        expires=datetime(2065, 4, 1).astimezone(tz),
+        expires=datetime(2065, 4, 1, tzinfo=tz),
     )
 
 

--- a/tests/core/test_ical.py
+++ b/tests/core/test_ical.py
@@ -1,7 +1,6 @@
 from datetime import timedelta
 
 from django.urls import reverse
-from django.utils.datetime_safe import strftime
 
 from ephios.core.models import AbstractParticipation
 
@@ -30,4 +29,4 @@ def test_user_event_feed(django_app, qualified_volunteer, event):
         )
     )
     assert response and event.title in response
-    assert strftime(individual_start_time, "%M") in response
+    assert individual_start_time.strftime("%M") in response

--- a/tests/core/test_views_group.py
+++ b/tests/core/test_views_group.py
@@ -12,7 +12,7 @@ class TestGroupView:
     def test_group_list(self, django_app, superuser, groups):
         response = django_app.get(reverse("core:group_list"), user=superuser)
         assert response.status_code == 200
-        assert response.html.findAll(text=Group.objects.all().values_list("name", flat=True))
+        assert response.html.findAll(string=Group.objects.all().values_list("name", flat=True))
         edit_links = [
             reverse("core:group_edit", kwargs={"pk": group_id})
             for group_id in Group.objects.all().values_list("id", flat=True)

--- a/tests/core/test_views_userprofile.py
+++ b/tests/core/test_views_userprofile.py
@@ -18,18 +18,18 @@ class TestUserProfileView:
         users = [superuser, manager, planner, volunteer, responsible_user]
         for user in users:
             response = django_app.get(reverse("core:settings_personal_data"), user=user)
-            assert response.html.find("dd", text=user.first_name)
-            assert response.html.find("dd", text=user.last_name)
-            assert response.html.find("dd", text=user.email)
+            assert response.html.find("dd", string=user.first_name)
+            assert response.html.find("dd", string=user.last_name)
+            assert response.html.find("dd", string=user.email)
             assert response.html.find(
-                "dd", text=date_format(user.date_of_birth, format="DATE_FORMAT")
+                "dd", string=date_format(user.date_of_birth, format="DATE_FORMAT")
             )
-            assert response.html.find("dd", text=user.phone)
+            assert response.html.find("dd", string=user.phone)
 
     def test_correct_qualifications(self, django_app, qualified_volunteer):
         response = django_app.get(reverse("core:settings_personal_data"), user=qualified_volunteer)
         for q in qualified_volunteer.qualifications:
-            assert q.expires is None or response.html.findAll("li", text=re.compile(f"{q.title}"))
+            assert q.expires is None or response.html.findAll("li", string=re.compile(f"{q.title}"))
 
     def test_userprofile_list_permission_required(self, django_app, volunteer):
         response = django_app.get(reverse("core:userprofile_list"), user=volunteer, status=403)
@@ -38,7 +38,9 @@ class TestUserProfileView:
     def test_userprofile_list(self, django_app, superuser):
         response = django_app.get(reverse("core:userprofile_list"), user=superuser)
         assert response.status_code == 200
-        assert response.html.findAll(text=UserProfile.objects.all().values_list("email", flat=True))
+        assert response.html.findAll(
+            string=UserProfile.objects.all().values_list("email", flat=True)
+        )
         edit_links = [
             reverse("core:userprofile_edit", kwargs={"pk": userprofile_id})
             for userprofile_id in UserProfile.objects.all().values_list("id", flat=True)

--- a/tests/core/test_workinghours.py
+++ b/tests/core/test_workinghours.py
@@ -11,14 +11,14 @@ class TestWorkingHours:
     def test_own_workinghours_without_hours(self, django_app, volunteer):
         response = django_app.get(reverse("core:workinghours_own"), user=volunteer)
         assert response.status_code == 200
-        assert response.html.find(text=f"{floatformat(0, arg=2)}")
+        assert response.html.find(string=f"{floatformat(0, arg=2)}")
 
     def test_own_workinghours(self, django_app, volunteer, workinghours):
         response = django_app.get(reverse("core:workinghours_own"), user=volunteer)
-        assert response.html.find(text=workinghours[0].reason)
-        assert response.html.find(text=workinghours[1].reason)
+        assert response.html.find(string=workinghours[0].reason)
+        assert response.html.find(string=workinghours[1].reason)
         total_hours = workinghours[0].hours + workinghours[1].hours
-        assert response.html.find(text=f"{floatformat(total_hours, arg=2)}")
+        assert response.html.find(string=f"{floatformat(total_hours, arg=2)}")
 
     def test_workinghours_rounding(self, django_app, volunteer, event):
         from ephios.core.models import AbstractParticipation, LocalParticipation
@@ -34,8 +34,8 @@ class TestWorkingHours:
 
     def test_workinghours_overview(self, django_app, superuser, volunteer, workinghours):
         response = django_app.get(reverse("core:workinghours_list"), user=superuser)
-        assert response.html.find(text=floatformat(workinghours[1].hours, arg=2))
-        assert not response.html.find(text=superuser.last_name)
+        assert response.html.find(string=floatformat(workinghours[1].hours, arg=2))
+        assert not response.html.find(string=superuser.last_name)
 
     def test_grant_permission(
         self, django_app, manager, superuser, groups, workinghours, volunteer
@@ -45,9 +45,9 @@ class TestWorkingHours:
         )
         response = django_app.get(reverse("core:workinghours_list"), user=volunteer, status=403)
         response = django_app.get(reverse("core:workinghours_list"), user=manager)
-        assert len(response.html.find_all("span", text=re.compile("^Add$"))) == 1
+        assert len(response.html.find_all("span", string=re.compile("^Add$"))) == 1
         response = django_app.get(reverse("core:workinghours_list"), user=superuser)
-        assert len(response.html.find_all("span", text=re.compile("^Add$"))) == 2
+        assert len(response.html.find_all("span", string=re.compile("^Add$"))) == 2
 
     def test_workinghours_delete(self, django_app, superuser, volunteer, workinghours, groups):
         response = django_app.get(

--- a/tests/plugins/simpleresource/test_resources.py
+++ b/tests/plugins/simpleresource/test_resources.py
@@ -7,8 +7,8 @@ from ephios.plugins.simpleresource.models import Resource, ResourceAllocation, R
 
 def test_resource_list(django_app, superuser, resources):
     response = django_app.get(reverse("simpleresource:resource_list"), user=superuser)
-    assert response.html.find(text=resources[0].title)
-    assert response.html.find(text=resources[1].title)
+    assert response.html.find(string=resources[0].title)
+    assert response.html.find(string=resources[1].title)
 
 
 def test_resource_edit(django_app, superuser, resources):
@@ -19,7 +19,7 @@ def test_resource_edit(django_app, superuser, resources):
     form["title"] = new_title
     response = form.submit().follow()
     assert response.status_code == 200
-    assert response.html.find(text=new_title)
+    assert response.html.find(string=new_title)
 
 
 def test_resource_delete(django_app, superuser, resources):
@@ -58,8 +58,8 @@ def test_resource_allocation_display(django_app, volunteer, groups, event, resou
     allocation = ResourceAllocation.objects.create(shift=event.shifts.first())
     allocation.resources.set([resources[0]])
     response = django_app.get(event.get_absolute_url(), user=volunteer)
-    assert response.html.find(text=re.compile(f"{resources[0].title}"))
-    assert not response.html.find(text=re.compile(f"{resources[1].title}"))
+    assert response.html.find(string=re.compile(f"{resources[0].title}"))
+    assert not response.html.find(string=re.compile(f"{resources[1].title}"))
 
 
 def test_resource_allocation_edit(django_app, superuser, groups, event, resources):


### PR DESCRIPTION
We are getting some warnings in our tests that can be fixed internally. Some remaining warnings require dependency updates. Esp. `django-dynamic-preferences` needs a new release to get the improvements from https://github.com/agateblue/django-dynamic-preferences/pull/287 

Here's what I did:

* [x] datetime fields receiving naive datetimes
* [x] deprecated bs4 `text` kwarg usage
* [x] use `tzinfo` instead of `astimezone`
* [x] not passing unsaved model instances to related filters
* `importlib._bootstrap>:283: DeprecationWarning`: the load_module() method is deprecated seems to be caused by reportlabs interal import logic
* `django.utils.timezone.utc` alias is deprecated --> that's the warning caused in dynamic-preferences 

