### PR TITLE
Change event_action_signal interface

### DIFF
--- a/ephios/core/signals.py
+++ b/ephios/core/signals.py
@@ -115,11 +115,11 @@ Once the user wants to perform the action, a POST request will be issued to this
 will contain a list of event ids on which the action should be performed.
 """
 
-register_event_action = PluginSignal()
+event_action = PluginSignal()
 """
 This signal is sent out to get a list of actions that a user can perform on a single event. The actions are
 displayed in the dropdown menu on the event detail view.
-Receivers receive a ``event`` keyword argument.
+Receivers receive a ``event`` and ``request`` keyword argument.
 Each action is represented by a dict with the keys ``url``, ``label`` and ``icon``.
 """
 

--- a/ephios/core/signals.py
+++ b/ephios/core/signals.py
@@ -118,8 +118,9 @@ will contain a list of event ids on which the action should be performed.
 register_event_action = PluginSignal()
 """
 This signal is sent out to get a list of actions that a user can perform on a single event. The actions are
-displayed in the dropdown menu on the event detail view. Each action is represented by a dict with the keys
-``url``, ``label`` and ``icon``. The given url will be called with a ``pk`` parameter containing the id of the event.
+displayed in the dropdown menu on the event detail view.
+Receivers receive a ``event`` keyword argument.
+Each action is represented by a dict with the keys ``url``, ``label`` and ``icon``.
 """
 
 homepage_info = PluginSignal()

--- a/ephios/core/templates/core/event_detail.html
+++ b/ephios/core/templates/core/event_detail.html
@@ -85,7 +85,7 @@
                                     {% trans "View edit history" %}
                                 </a></li>
                             {% endif %}
-                            {% event_plugin_actions event %}
+                            {% event_plugin_actions view %}
                         </ul>
                     </div>
                 {% endif %}

--- a/ephios/core/templatetags/event_extras.py
+++ b/ephios/core/templatetags/event_extras.py
@@ -3,7 +3,6 @@ import operator
 from functools import reduce
 
 from django import template
-from django.urls import reverse
 from django.utils import timezone
 from django.utils.html import format_html
 from django.utils.safestring import mark_safe
@@ -165,10 +164,10 @@ def homepage_plugin_content(request):
 @register.simple_tag(name="event_plugin_actions")
 def event_plugin_actions(event):
     html = ""
-    for _, actions in register_event_action.send(None):
+    for _, actions in register_event_action.send(None, event=event):
         html += "".join(
             [
-                f"<li><a class='dropdown-item' href='{reverse(action['url'], kwargs={'pk': event.id})}'><span class='fas {action['icon']}'></span> {action['label']}</a></li>"
+                f"<li><a class='dropdown-item' href='{action['url']}'><span class='fas {action['icon']}'></span> {action['label']}</a></li>"
                 for action in actions
             ]
         )

--- a/ephios/core/templatetags/event_extras.py
+++ b/ephios/core/templatetags/event_extras.py
@@ -9,9 +9,9 @@ from django.utils.safestring import mark_safe
 
 from ephios.core.models import AbstractParticipation, EventType, UserProfile
 from ephios.core.signals import (
+    event_action,
     event_info,
     homepage_info,
-    register_event_action,
     register_event_bulk_action,
     shift_info,
 )
@@ -162,9 +162,11 @@ def homepage_plugin_content(request):
 
 
 @register.simple_tag(name="event_plugin_actions")
-def event_plugin_actions(event):
+def event_plugin_actions(event_detail_view):
     html = ""
-    for _, actions in register_event_action.send(None, event=event):
+    for _, actions in event_action.send(
+        None, event=event_detail_view.object, request=event_detail_view.request
+    ):
         html += "".join(
             [
                 f"<li><a class='dropdown-item' href='{action['url']}'><span class='fas {action['icon']}'></span> {action['label']}</a></li>"


### PR DESCRIPTION
I think this change makes the interface more flexible, as receivers can reverse the url themselves or do something else entirely or just not return an action if not appropriate for that event.