### PR TITLE
staging build: fetch all commits

### DIFF
--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -12,6 +12,8 @@ jobs:
         python-version: [ 3.8 ]
     steps:
       - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
       - name: Install poetry
         run: pipx install poetry
       - uses: actions/setup-python@v4


### PR DESCRIPTION
The staging build is using dynamic versioning, but not setting the version correctly:

![image](https://github.com/ephios-dev/ephios/assets/5970076/c0fcaa75-f2de-4343-b415-befda2bbe1cc)

I'm guessing that's because GH actions only fetches the latest commit by default. So lets fix that!
(see https://github.com/actions/checkout#checkout-v3 )