### PR TITLE
PWA: unblur spinner on pageshow

### DIFF
--- a/ephios/static/ephios/js/main.js
+++ b/ephios/static/ephios/js/main.js
@@ -54,10 +54,16 @@ $(document).ready(function () {
     if (navigator.standalone || window.matchMedia('(display-mode: standalone)').matches) {
         $(window).on('beforeunload', function () {
             $('.blur-on-unload').addClass("unloading");
-            $('#unloading-spinner').removeClass("d-none")
+            $('#unloading-spinner').removeClass("d-none");
         });
     }
+    // when hitting "back" button in browser, the page is not reloaded so we need to remove the blur manually
+    window.addEventListener('pageshow', function (event) {
+        $('.blur-on-unload').removeClass("unloading");
+        $('#unloading-spinner').addClass("d-none");
+    });
 })
+
 
 // Initialize the service worker
 if ('serviceWorker' in navigator) {


### PR DESCRIPTION
happened when hitting the back button and it was bugging me so hard I fixed it tonight :muscle: 
These were the interesting reads:

* pointing me to the event that worked on pageload: https://christopheraue.net/design/fading-pages-on-load-and-unload
* more info on the page lifecycle and the chrome exclusive APIs if this fix does not work everywhere: https://developer.chrome.com/blog/page-lifecycle-api/

This is related to my comments on #357, but not the initial part about it not working on iOS. Maybe @jeriox can have another look?