### PR TITLE
refactor template getter for shift configuration form rendering

### DIFF
--- a/ephios/core/signup/methods.py
+++ b/ephios/core/signup/methods.py
@@ -14,7 +14,6 @@ from django.core.exceptions import PermissionDenied, ValidationError
 from django.db import transaction
 from django.db.models import Q
 from django.shortcuts import redirect
-from django.template import Context, Template
 from django.template.loader import get_template
 from django.urls import reverse
 from django.utils import timezone
@@ -499,6 +498,7 @@ class BaseSignupMethod:
         return BaseDispositionParticipationForm
 
     configuration_form_class = BaseSignupMethodConfigurationForm
+    configuration_form_template_name = "core/signup_configuration_form.html"
 
     @property
     def signup_view_class(self):
@@ -768,11 +768,7 @@ class BaseSignupMethod:
 
     def render_configuration_form(self, *args, form=None, **kwargs):
         form = form or self.get_configuration_form(*args, event=self.event, **kwargs)
-        template = self.get_configuration_form_template().render(Context({"form": form}))
-        return template
-
-    def get_configuration_form_template(self) -> Template:
-        return Template(template_string="{% load crispy_forms_filters %}{{ form|crispy }}")
+        return get_template(self.configuration_form_template_name).render({"form": form})
 
 
 @dataclasses.dataclass(frozen=True)

--- a/ephios/core/signup/methods.py
+++ b/ephios/core/signup/methods.py
@@ -768,10 +768,11 @@ class BaseSignupMethod:
 
     def render_configuration_form(self, *args, form=None, **kwargs):
         form = form or self.get_configuration_form(*args, event=self.event, **kwargs)
-        template = Template(
-            template_string="{% load crispy_forms_filters %}{{ form|crispy }}"
-        ).render(Context({"form": form}))
+        template = self.get_configuration_form_template().render(Context({"form": form}))
         return template
+
+    def get_configuration_form_template(self) -> Template:
+        return Template(template_string="{% load crispy_forms_filters %}{{ form|crispy }}")
 
 
 @dataclasses.dataclass(frozen=True)

--- a/ephios/core/signup/methods.py
+++ b/ephios/core/signup/methods.py
@@ -451,6 +451,7 @@ def check_conflicting_participations(method, participant):
 
 
 class BaseSignupMethodConfigurationForm(forms.Form):
+    template_name = "core/signup_configuration_form.html"
     minimum_age = forms.IntegerField(
         required=False, min_value=1, max_value=999, initial=None, label=_("Minimum age")
     )
@@ -498,7 +499,6 @@ class BaseSignupMethod:
         return BaseDispositionParticipationForm
 
     configuration_form_class = BaseSignupMethodConfigurationForm
-    configuration_form_template_name = "core/signup_configuration_form.html"
 
     @property
     def signup_view_class(self):
@@ -763,12 +763,10 @@ class BaseSignupMethod:
     def get_configuration_form(self, *args, **kwargs):
         if self.shift is not None:
             kwargs.setdefault("initial", self.configuration.__dict__)
+        if self.event is not None:
+            kwargs.setdefault("event", self.event)
         form = self.configuration_form_class(*args, **kwargs)
         return form
-
-    def render_configuration_form(self, *args, form=None, **kwargs):
-        form = form or self.get_configuration_form(*args, event=self.event, **kwargs)
-        return get_template(self.configuration_form_template_name).render({"form": form})
 
 
 @dataclasses.dataclass(frozen=True)

--- a/ephios/core/templates/core/signup_configuration_form.html
+++ b/ephios/core/templates/core/signup_configuration_form.html
@@ -1,0 +1,2 @@
+{% load crispy_forms_filters %}
+{{ form|crispy }}

--- a/ephios/core/views/shift.py
+++ b/ephios/core/views/shift.py
@@ -70,9 +70,7 @@ class ShiftCreateView(CustomPermissionRequiredMixin, PluginFormMixin, TemplateVi
                 return self.render_to_response(
                     self.get_context_data(
                         form=form,
-                        configuration_form=signup_method.render_configuration_form(
-                            form=configuration_form
-                        ),
+                        configuration_form=configuration_form,
                     )
                 )
 
@@ -103,7 +101,7 @@ class ShiftConfigurationFormView(CustomPermissionRequiredMixin, SingleObjectMixi
 
     def get(self, request, *args, **kwargs):
         signup_method = signup_method_from_slug(self.kwargs.get("slug"), event=self.get_object())
-        return HttpResponse(signup_method.render_configuration_form())
+        return HttpResponse(signup_method.get_configuration_form().render())
 
 
 class ShiftUpdateView(
@@ -129,7 +127,7 @@ class ShiftUpdateView(
         )
 
     def get_configuration_form(self):
-        return self.object.signup_method.render_configuration_form(data=self.request.POST or None)
+        return self.object.signup_method.get_configuration_form(data=self.request.POST or None)
 
     def get_context_data(self, **kwargs):
         self.object = self.get_object()
@@ -168,7 +166,7 @@ class ShiftUpdateView(
         return self.render_to_response(
             self.get_context_data(
                 form=form,
-                configuration_form=signup_method.render_configuration_form(form=configuration_form),
+                configuration_form=configuration_form,
             )
         )
 

--- a/ephios/plugins/basesignup/signup/coupled_signup.py
+++ b/ephios/plugins/basesignup/signup/coupled_signup.py
@@ -26,6 +26,7 @@ class CoupledSignupMethod(RenderParticipationPillsShiftStateMixin, BaseSignupMet
     @property
     def configuration_form_class(self):
         class ConfigurationForm(forms.Form):
+            template_name = "core/signup_configuration_form.html"
             leader_shift_id = forms.ModelChoiceField(
                 label=_("shift to mirror participation from"),
                 required=True,

--- a/ephios/plugins/basesignup/signup/no_selfservice.py
+++ b/ephios/plugins/basesignup/signup/no_selfservice.py
@@ -10,6 +10,7 @@ from ephios.plugins.basesignup.signup.common import (
 
 
 class NoSelfserviceConfigurationForm(forms.Form):
+    template_name = "core/signup_configuration_form.html"
     no_selfservice_explanation = forms.CharField(
         label=_("Explanation"),
         required=False,

--- a/ephios/plugins/basesignup/signup/section_based.py
+++ b/ephios/plugins/basesignup/signup/section_based.py
@@ -116,6 +116,8 @@ SectionsFormset = forms.formset_factory(
 
 
 class SectionBasedConfigurationForm(BaseSignupMethod.configuration_form_class):
+    template_name = "basesignup/section_based/configuration_form.html"
+
     choose_preferred_section = forms.BooleanField(
         label=_("Participants must provide a preferred section"),
         help_text=_("This only makes sense if you configure multiple sections."),
@@ -216,7 +218,6 @@ class SectionBasedSignupMethod(BaseSignupMethod):
     disposition_participation_form_class = SectionBasedDispositionParticipationForm
 
     configuration_form_class = SectionBasedConfigurationForm
-    configuration_form_template_name = "basesignup/section_based/configuration_form.html"
     shift_state_template_name = "basesignup/section_based/fragment_state.html"
 
     def _get_signup_stats_per_section(self, participations=None):

--- a/ephios/plugins/basesignup/signup/section_based.py
+++ b/ephios/plugins/basesignup/signup/section_based.py
@@ -6,7 +6,6 @@ from operator import itemgetter
 
 from django import forms
 from django.core.exceptions import ValidationError
-from django.template.loader import get_template
 from django.utils.translation import gettext_lazy as _
 from django_select2.forms import Select2MultipleWidget
 from dynamic_preferences.registries import global_preferences_registry
@@ -217,6 +216,7 @@ class SectionBasedSignupMethod(BaseSignupMethod):
     disposition_participation_form_class = SectionBasedDispositionParticipationForm
 
     configuration_form_class = SectionBasedConfigurationForm
+    configuration_form_template_name = "basesignup/section_based/configuration_form.html"
     shift_state_template_name = "basesignup/section_based/fragment_state.html"
 
     def _get_signup_stats_per_section(self, participations=None):
@@ -294,10 +294,6 @@ class SectionBasedSignupMethod(BaseSignupMethod):
     ) -> AbstractParticipation:
         participation.state = AbstractParticipation.States.REQUESTED
         return participation
-
-    def get_configuration_form_template(self):
-        """We overwrite the template to render the formset."""
-        return get_template("basesignup/section_based/configuration_form.html")
 
     def get_shift_state_context_data(self, request, **kwargs):
         context_data = super().get_shift_state_context_data(request)

--- a/ephios/plugins/basesignup/signup/section_based.py
+++ b/ephios/plugins/basesignup/signup/section_based.py
@@ -295,13 +295,9 @@ class SectionBasedSignupMethod(BaseSignupMethod):
         participation.state = AbstractParticipation.States.REQUESTED
         return participation
 
-    def render_configuration_form(self, *args, form=None, **kwargs):
+    def get_configuration_form_template(self):
         """We overwrite the template to render the formset."""
-        form = form or self.get_configuration_form(*args, event=self.event, **kwargs)
-        template = get_template("basesignup/section_based/configuration_form.html").render(
-            {"form": form}
-        )
-        return template
+        return get_template("basesignup/section_based/configuration_form.html")
 
     def get_shift_state_context_data(self, request, **kwargs):
         context_data = super().get_shift_state_context_data(request)


### PR DESCRIPTION
all three implementations of `render_configuration_form()` were using the same line of code `form = form or self.get_configuration_form(*args, event=self.event, **kwargs)` and only a different template to render the form in. Unfortunately, the implementation in signup_beachguard was missing the `event=self.event` part which led to the form not being rendered. As the implementations were identical anyways, I decided to refactor the template getting into a separate method