### PR TITLE
Signup configuration form improvements

### DIFF
--- a/ephios/core/forms/events.py
+++ b/ephios/core/forms/events.py
@@ -14,6 +14,7 @@ from django.template.loader import render_to_string
 from django.utils.safestring import mark_safe
 from django.utils.timezone import make_aware
 from django.utils.translation import gettext as _
+from django.utils.translation import pgettext
 from django_select2.forms import Select2MultipleWidget
 from dynamic_preferences.forms import PreferenceForm
 from guardian.shortcuts import assign_perm, get_objects_for_user, get_users_with_perms, remove_perm
@@ -177,7 +178,12 @@ class ShiftForm(forms.ModelForm):
             "signup_method_slug": mark_safe(
                 _(
                     "Signup method for this shift. Explanations for the signup methods can be found in the <a href='{url}'>documentation</a>."
-                ).format(url="https://docs.ephios.de/de/stable/user/planner/signup_methods.html")
+                ).format(
+                    url=pgettext(
+                        "localized docs link",
+                        "https://docs.ephios.de/en/stable/user/events/signup_methods.html#availabe-signup-methods",
+                    )
+                )
             )
         }
 

--- a/ephios/core/signup/methods.py
+++ b/ephios/core/signup/methods.py
@@ -14,7 +14,6 @@ from django.core.exceptions import PermissionDenied, ValidationError
 from django.db import transaction
 from django.db.models import Q
 from django.shortcuts import redirect
-from django.template import Context, Template
 from django.template.loader import get_template
 from django.urls import reverse
 from django.utils import timezone
@@ -452,6 +451,7 @@ def check_conflicting_participations(method, participant):
 
 
 class BaseSignupMethodConfigurationForm(forms.Form):
+    template_name = "core/signup_configuration_form.html"
     minimum_age = forms.IntegerField(
         required=False, min_value=1, max_value=999, initial=None, label=_("Minimum age")
     )
@@ -763,15 +763,10 @@ class BaseSignupMethod:
     def get_configuration_form(self, *args, **kwargs):
         if self.shift is not None:
             kwargs.setdefault("initial", self.configuration.__dict__)
+        if self.event is not None:
+            kwargs.setdefault("event", self.event)
         form = self.configuration_form_class(*args, **kwargs)
         return form
-
-    def render_configuration_form(self, *args, form=None, **kwargs):
-        form = form or self.get_configuration_form(*args, event=self.event, **kwargs)
-        template = Template(
-            template_string="{% load crispy_forms_filters %}{{ form|crispy }}"
-        ).render(Context({"form": form}))
-        return template
 
 
 @dataclasses.dataclass(frozen=True)

--- a/ephios/core/templates/core/shift_form.html
+++ b/ephios/core/templates/core/shift_form.html
@@ -24,15 +24,16 @@
             <form method="post" class="form">
                 {% csrf_token %}
                 {{ form|crispy }}
+                <hr class="border border-secondary border-dark opacity-75">
                 <div id="configuration_form">
                     {{ configuration_form }}
                 </div>
+                <hr class="border border-secondary border-dark opacity-75">
                 <div class="plugin-forms">
                     {% for plugin_form in plugin_forms %}
                         {{ plugin_form.render }}
                     {% endfor %}
                 </div>
-
                 <div class="form-group">
                     {% if object or event.active %}
                         <a role="button" class="btn btn-secondary"
@@ -65,8 +66,12 @@
                 <div class="card-body">
                     <h5 class="card-title">
                         {{ event.title }}
-                        <small class="float-end"><a href="{% url "core:event_edit" event.pk %}"><span
-                                class="fas fa-edit"></span> {% trans "Edit" %}</a></small>
+                        <small class="float-end">
+                            <a href="{% url "core:event_edit" event.pk %}">
+                                <span class="fas fa-edit"></span>
+                                {% trans "Edit" %}
+                            </a>
+                        </small>
                     </h5>
                     <p class="card-text">
                         {% trans "Event type" %}: {{ event.type }}<br>
@@ -82,11 +87,18 @@
                     <div class="card-body">
                         <h5 class="card-subtitle mb-2 text-muted">{% trans "Shift" %}</h5>
                         <p class="card-text">{% trans "You are currently adding this shift" %}</p>
+                    </div>
                 </div>
             {% endif %}
         </div>
     </div>
-    <script type="application/json" id="configuration_form_url">{"url": "{% url "core:signupmethod_configurationform" event.id "METHOD_SLUG" %}"}</script>
+    <script type="application/json" id="configuration_form_url">
+        {% if object %}
+            {"url":"{% url "core:signupmethod_configurationform" event.id "METHOD_SLUG" %}?shift_id={{ object.id }}"}
+        {% else %}
+            {"url":"{% url "core:signupmethod_configurationform" event.id "METHOD_SLUG" %}"}
+        {% endif %}
+    </script>
 {% endblock %}
 
 {% block javascript %}

--- a/ephios/core/templates/core/signup_configuration_form.html
+++ b/ephios/core/templates/core/signup_configuration_form.html
@@ -1,0 +1,2 @@
+{% load crispy_forms_filters %}
+{{ form|crispy }}

--- a/ephios/core/views/shift.py
+++ b/ephios/core/views/shift.py
@@ -70,9 +70,7 @@ class ShiftCreateView(CustomPermissionRequiredMixin, PluginFormMixin, TemplateVi
                 return self.render_to_response(
                     self.get_context_data(
                         form=form,
-                        configuration_form=signup_method.render_configuration_form(
-                            form=configuration_form
-                        ),
+                        configuration_form=configuration_form,
                     )
                 )
 
@@ -103,7 +101,7 @@ class ShiftConfigurationFormView(CustomPermissionRequiredMixin, SingleObjectMixi
 
     def get(self, request, *args, **kwargs):
         signup_method = signup_method_from_slug(self.kwargs.get("slug"), event=self.get_object())
-        return HttpResponse(signup_method.render_configuration_form())
+        return HttpResponse(signup_method.get_configuration_form().render())
 
 
 class ShiftUpdateView(
@@ -129,7 +127,7 @@ class ShiftUpdateView(
         )
 
     def get_configuration_form(self):
-        return self.object.signup_method.render_configuration_form(data=self.request.POST or None)
+        return self.object.signup_method.get_configuration_form(data=self.request.POST or None)
 
     def get_context_data(self, **kwargs):
         self.object = self.get_object()
@@ -168,7 +166,7 @@ class ShiftUpdateView(
         return self.render_to_response(
             self.get_context_data(
                 form=form,
-                configuration_form=signup_method.render_configuration_form(form=configuration_form),
+                configuration_form=configuration_form,
             )
         )
 

--- a/ephios/core/views/shift.py
+++ b/ephios/core/views/shift.py
@@ -100,7 +100,13 @@ class ShiftConfigurationFormView(CustomPermissionRequiredMixin, SingleObjectMixi
     pk_url_kwarg = "event_id"
 
     def get(self, request, *args, **kwargs):
-        signup_method = signup_method_from_slug(self.kwargs.get("slug"), event=self.get_object())
+        try:
+            shift = self.get_object().shifts.get(pk=request.GET.get("shift_id") or None)
+        except Shift.DoesNotExist:
+            shift = None
+        signup_method = signup_method_from_slug(
+            self.kwargs.get("slug"), event=self.get_object(), shift=shift
+        )
         return HttpResponse(signup_method.get_configuration_form().render())
 
 

--- a/ephios/plugins/basesignup/signup/coupled_signup.py
+++ b/ephios/plugins/basesignup/signup/coupled_signup.py
@@ -26,6 +26,7 @@ class CoupledSignupMethod(RenderParticipationPillsShiftStateMixin, BaseSignupMet
     @property
     def configuration_form_class(self):
         class ConfigurationForm(forms.Form):
+            template_name = "core/signup_configuration_form.html"
             leader_shift_id = forms.ModelChoiceField(
                 label=_("shift to mirror participation from"),
                 required=True,

--- a/ephios/plugins/basesignup/signup/no_selfservice.py
+++ b/ephios/plugins/basesignup/signup/no_selfservice.py
@@ -10,6 +10,7 @@ from ephios.plugins.basesignup.signup.common import (
 
 
 class NoSelfserviceConfigurationForm(forms.Form):
+    template_name = "core/signup_configuration_form.html"
     no_selfservice_explanation = forms.CharField(
         label=_("Explanation"),
         required=False,

--- a/ephios/plugins/basesignup/signup/section_based.py
+++ b/ephios/plugins/basesignup/signup/section_based.py
@@ -6,7 +6,6 @@ from operator import itemgetter
 
 from django import forms
 from django.core.exceptions import ValidationError
-from django.template.loader import get_template
 from django.utils.translation import gettext_lazy as _
 from django_select2.forms import Select2MultipleWidget
 from dynamic_preferences.registries import global_preferences_registry
@@ -117,6 +116,8 @@ SectionsFormset = forms.formset_factory(
 
 
 class SectionBasedConfigurationForm(BaseSignupMethod.configuration_form_class):
+    template_name = "basesignup/section_based/configuration_form.html"
+
     choose_preferred_section = forms.BooleanField(
         label=_("Participants must provide a preferred section"),
         help_text=_("This only makes sense if you configure multiple sections."),
@@ -294,14 +295,6 @@ class SectionBasedSignupMethod(BaseSignupMethod):
     ) -> AbstractParticipation:
         participation.state = AbstractParticipation.States.REQUESTED
         return participation
-
-    def render_configuration_form(self, *args, form=None, **kwargs):
-        """We overwrite the template to render the formset."""
-        form = form or self.get_configuration_form(*args, event=self.event, **kwargs)
-        template = get_template("basesignup/section_based/configuration_form.html").render(
-            {"form": form}
-        )
-        return template
 
     def get_shift_state_context_data(self, request, **kwargs):
         context_data = super().get_shift_state_context_data(request)

--- a/ephios/plugins/basesignup/templates/basesignup/section_based/configuration_form.html
+++ b/ephios/plugins/basesignup/templates/basesignup/section_based/configuration_form.html
@@ -70,10 +70,10 @@
                                 class="fas fa-trash-alt"></span></button>
                     </div>
                 </div>
-            </div>
-            <div class="d-none">
-                {{ form.sections_formset.empty_form.DELETE }}
-                {{ form.sections_formset.empty_form.uuid }}
+                <div class="d-none">
+                    {{ form.sections_formset.empty_form.DELETE }}
+                    {{ form.sections_formset.empty_form.uuid }}
+                </div>
             </div>
         {% endescapescript %}
     </script>


### PR DESCRIPTION
* contains commits of #990 improving/fixing the rendering of the configuration form
* adds horizontal rules around the signup method configuration form to make it visually a little easier to see that section
* when js-loading the configuration form, also pass the shift_id if available so the value of common fields is kept (also when going back to the original method)
* fix a bug where in section-based-signup, sections added could not be removed right again
* fix the link to the signup method documentation

Now after looking at the code again I again thought we need to factor out an `AbstractSignupMethod` from the `BaseSignupMethod` and probably do the same for the config form. The class is way to overloaded.