### PR TITLE
PWA Fixups

### DIFF
--- a/ephios/core/templates/core/serviceworker.js
+++ b/ephios/core/templates/core/serviceworker.js
@@ -23,7 +23,9 @@ self.addEventListener('activate', event => {
         caches.keys().then(cacheNames => {
             return Promise.all(
                 cacheNames
-                    .filter(cacheName => (cacheName.startsWith("ephios-pwa-")))
+                    .filter(cacheName => (
+                        cacheName.startsWith("ephios-pwa-") || cacheName.startsWith("django-pwa-") // old cache names
+                    ))
                     .filter(cacheName => (cacheName !== CACHE_NAME))
                     .map(cacheName => caches.delete(cacheName))
             );

--- a/ephios/core/templates/core/serviceworker.js
+++ b/ephios/core/templates/core/serviceworker.js
@@ -71,7 +71,7 @@ async function cacheThenNetwork(event) {
         return cache_response;
     }
     return fetchAndCacheOrCatch(event, async (err) => {
-        return caches.match('{{ offline_url }}', {ignoreVary: true});
+        throw err; // already checked the cache, so we can only fail
     })
 }
 


### PR DESCRIPTION
* [x] instead of returning the `/offline/` template for `cacheThenNetwork`-Requests, just fail.
* [x] also delete the caches going by the old cache naming scheme.