### PR TITLE
add help_text to page slug

### DIFF
--- a/ephios/plugins/pages/models.py
+++ b/ephios/plugins/pages/models.py
@@ -5,7 +5,12 @@ from django.utils.translation import gettext_lazy as _
 class Page(models.Model):
     title = models.CharField(verbose_name=_("Title"), max_length=250)
     content = models.TextField(_("Content"), blank=True)
-    slug = models.SlugField(_("Slug"), max_length=250, unique=True)
+    slug = models.SlugField(
+        _("URL slug"),
+        help_text=_("The slug is used to generate the page's URL."),
+        max_length=250,
+        unique=True,
+    )
     show_in_footer = models.BooleanField(_("Show in footer"), default=False)
     publicly_visible = models.BooleanField(_("Publicly visible"), default=False)
 

--- a/ephios/plugins/pages/views.py
+++ b/ephios/plugins/pages/views.py
@@ -29,7 +29,7 @@ class PageView(DetailView):
 class PageCreateView(CustomPermissionRequiredMixin, CreateView):
     model = Page
     permission_required = "pages.add_page"
-    fields = ["title", "content", "slug", "show_in_footer", "publicly_visible"]
+    fields = ["title", "slug", "content", "show_in_footer", "publicly_visible"]
 
     def get_success_url(self):
         messages.success(self.request, _("Page saved successfully."))
@@ -39,7 +39,7 @@ class PageCreateView(CustomPermissionRequiredMixin, CreateView):
 class PageUpdateView(CustomPermissionRequiredMixin, UpdateView):
     model = Page
     permission_required = "pages.change_page"
-    fields = ["title", "content", "slug", "show_in_footer", "publicly_visible"]
+    fields = ["title", "slug", "content", "show_in_footer", "publicly_visible"]
 
     def get_success_url(self):
         messages.success(self.request, _("Page saved successfully."))


### PR DESCRIPTION
closes #833 

würde dann `slug` als `Kurzform` übersetzen
