### PR TITLE
make static root absolute

### DIFF
--- a/ephios/settings.py
+++ b/ephios/settings.py
@@ -194,7 +194,11 @@ USE_TZ = True
 # https://docs.djangoproject.com/en/3.0/howto/static-files/
 
 STATIC_URL = env.str("STATIC_URL")
+
 STATIC_ROOT = env.str("STATIC_ROOT")
+if not os.path.isabs(STATIC_ROOT):
+    STATIC_ROOT = os.path.join(BASE_DIR, STATIC_ROOT)
+
 STATICFILES_DIRS = (os.path.join(BASE_DIR, "ephios/static"),)
 STATICFILES_FINDERS = (
     "django.contrib.staticfiles.finders.FileSystemFinder",


### PR DESCRIPTION
Why? Because the default `.env` value of `data/static/` meant that if e.g. tests were run from a non `BASE_DIR` working directory django would go look for static files in `ephios/tests/data/static/` which would fail (usally with compressor complaining about not finding some i18n-js-file).