### PR TITLE
dont clear names on missing oidc claims

### DIFF
--- a/ephios/extra/auth.py
+++ b/ephios/extra/auth.py
@@ -13,8 +13,9 @@ class EphiosOIDCAB(OIDCAuthenticationBackend):
         return user
 
     def update_user(self, user, claims):
-        user.first_name = claims.get("given_name", "")
-        user.last_name = claims.get("family_name", "")
+        if "given_name" in claims:
+            user.first_name = claims["given_name"]
+        if "family_name" in claims:
+            user.last_name = claims["family_name"]
         user.save()
-
         return user


### PR DESCRIPTION
Having these claim names hardcoded is still somewhat hacky. We'd need to change this with the OIDC rework. 
Nextcloud for example only has the full name inside the `name` claim:

https://github.com/H2CK/oidc/wiki/User-Documentation#scopes