### PR TITLE
Fix event slug being empty leading to reverse errors

### DIFF
--- a/ephios/core/models/events.py
+++ b/ephios/core/models/events.py
@@ -120,7 +120,7 @@ class Event(Model):
         return str(self.title)
 
     def get_canonical_slug(self):
-        return slugify(self.title)
+        return slugify(self.title) or str(self.id)
 
     def get_absolute_url(self):
         from django.urls import reverse

--- a/tests/core/test_event_detail.py
+++ b/tests/core/test_event_detail.py
@@ -9,3 +9,15 @@ def test_slug_redirect(django_app, volunteer, event):
     assert response.location  # is a redirect
     response = response.follow()
     assert event.title in response
+
+
+def test_event_slug_with_empty_name(django_app, volunteer, event):
+    event.title = ""
+    event.save()
+    response = django_app.get(
+        reverse("core:event_detail", kwargs=dict(pk=event.pk, slug="nottheactualslug")),
+        user=volunteer,
+    )
+    assert response.location  # is a redirect
+    response = response.follow()
+    assert event.description in response


### PR DESCRIPTION
```
NoReverseMatch at /
Reverse for 'event_detail' with keyword arguments '{'pk': 69, 'slug': ''}' not found. 1 pattern(s) tried: ['events/(?P<pk>[0-9]+)\\-(?P<slug>[-a-zA-Z0-9_]+)/\\Z']
```