### PR TITLE
Federation Refactor

### DIFF
--- a/ephios/api/access/views.py
+++ b/ephios/api/access/views.py
@@ -19,13 +19,33 @@ from ephios.extra.mixins import StaffRequiredMixin
 from ephios.extra.widgets import CustomSplitDateTimeWidget
 
 
-class AllUserApplicationList(StaffRequiredMixin, oauth2_views.ApplicationList):
+class IgnoreApplicationOwnerMixin:
     def get_queryset(self):
         return get_application_model().objects.all()
 
 
-class ApplicationDelete(oauth2_views.ApplicationDelete):
+class AllUserApplicationList(
+    StaffRequiredMixin, IgnoreApplicationOwnerMixin, oauth2_views.ApplicationList
+):
+    pass
+
+
+class ApplicationDetail(
+    StaffRequiredMixin, IgnoreApplicationOwnerMixin, oauth2_views.ApplicationDetail
+):
+    pass
+
+
+class ApplicationDelete(
+    StaffRequiredMixin, IgnoreApplicationOwnerMixin, oauth2_views.ApplicationDelete
+):
     success_url = reverse_lazy("api:settings-oauth-app-list")
+
+
+class ApplicationUpdate(
+    StaffRequiredMixin, IgnoreApplicationOwnerMixin, oauth2_views.ApplicationUpdate
+):
+    pass
 
 
 class AccessTokensListView(oauth2_views.AuthorizedTokensListView):

--- a/ephios/api/urls.py
+++ b/ephios/api/urls.py
@@ -11,6 +11,8 @@ from ephios.api.access.views import (
     AccessTokensListView,
     AllUserApplicationList,
     ApplicationDelete,
+    ApplicationDetail,
+    ApplicationUpdate,
 )
 from ephios.api.views.events import EventViewSet
 from ephios.api.views.users import UserProfileMeView
@@ -50,7 +52,7 @@ urlpatterns = [
                 # Application management views
                 path(
                     "applications/",
-                    staff_required(AllUserApplicationList.as_view()),
+                    AllUserApplicationList.as_view(),
                     name="settings-oauth-app-list",
                 ),
                 path(
@@ -60,17 +62,17 @@ urlpatterns = [
                 ),
                 path(
                     "applications/<int:pk>/",
-                    staff_required(oauth2_views.ApplicationDetail.as_view()),
+                    ApplicationDetail.as_view(),
                     name="settings-oauth-app-detail",
                 ),
                 path(
                     "applications/<int:pk>/delete/",
-                    staff_required(ApplicationDelete.as_view()),
+                    ApplicationDelete.as_view(),
                     name="settings-oauth-app-delete",
                 ),
                 path(
                     "applications/<int:pk>/update/",
-                    staff_required(oauth2_views.ApplicationUpdate.as_view()),
+                    ApplicationUpdate.as_view(),
                     name="settings-oauth-app-update",
                 ),
             ]

--- a/ephios/plugins/federation/forms.py
+++ b/ephios/plugins/federation/forms.py
@@ -65,9 +65,7 @@ class RedeemInviteCodeForm(forms.Form):
 
     def clean_code(self):
         try:
-            data = json.loads(
-                base64.b64decode(self.cleaned_data["code"].encode("ascii")).decode("ascii")
-            )
+            data = json.loads(base64.b64decode(self.cleaned_data["code"].encode()).decode())
             if settings.GET_SITE_URL() != data["guest_url"]:
                 raise ValidationError(_("This invite code is not issued for this instance."))
         except (binascii.Error, JSONDecodeError, KeyError) as exc:

--- a/ephios/plugins/federation/forms.py
+++ b/ephios/plugins/federation/forms.py
@@ -2,26 +2,16 @@ import base64
 import binascii
 import json
 from json import JSONDecodeError
-from urllib.parse import urljoin, urlparse
+from urllib.parse import urlparse
 
-import requests
 from django import forms
 from django.conf import settings
 from django.core.exceptions import ValidationError
 from django.forms import CheckboxSelectMultiple
-from django.urls import reverse
 from django.utils.translation import gettext as _
-from dynamic_preferences.registries import global_preferences_registry
-from requests import HTTPError, ReadTimeout
 
-from ephios.api.models import Application
 from ephios.core.forms.events import BasePluginFormMixin
-from ephios.plugins.federation.models import (
-    FederatedEventShare,
-    FederatedGuest,
-    FederatedHost,
-    InviteCode,
-)
+from ephios.plugins.federation.models import FederatedEventShare, FederatedGuest, InviteCode
 
 
 class EventAllowFederationForm(BasePluginFormMixin, forms.Form):
@@ -80,31 +70,7 @@ class RedeemInviteCodeForm(forms.Form):
             )
             if settings.GET_SITE_URL() != data["guest_url"]:
                 raise ValidationError(_("This invite code is not issued for this instance."))
-            oauth_application = Application(
-                client_type=Application.CLIENT_CONFIDENTIAL,
-                authorization_grant_type=Application.GRANT_AUTHORIZATION_CODE,
-                redirect_uris=urljoin(data["host_url"], reverse("federation:oauth_callback")),
-            )
-            response = requests.post(
-                urljoin(data["host_url"], reverse("federation:redeem_invite_code")),
-                data={
-                    "name": global_preferences_registry.manager()["general__organization_name"],
-                    "url": data["guest_url"],
-                    "client_id": oauth_application.client_id,
-                    "client_secret": oauth_application.client_secret,
-                    "code": data["code"],
-                },
-                timeout=10,
-            )
-            response.raise_for_status()
-            response_data = response.json()
-            oauth_application.name = response_data["host_name"]
-            oauth_application.save()
-            FederatedHost.objects.create(
-                name=response_data["host_name"],
-                url=data["host_url"],
-                access_token=response_data["access_token"],
-                oauth_application=oauth_application,
-            )
-        except (binascii.Error, JSONDecodeError, KeyError, HTTPError, ReadTimeout) as exc:
+        except (binascii.Error, JSONDecodeError, KeyError) as exc:
             raise ValidationError(_("Invalid code")) from exc
+        self.code_data = data
+        return self.cleaned_data["code"]

--- a/ephios/plugins/federation/models.py
+++ b/ephios/plugins/federation/models.py
@@ -94,8 +94,8 @@ class InviteCode(models.Model):
         return base64.b64encode(
             json.dumps(
                 {"guest_url": self.url, "code": self.code, "host_url": settings.GET_SITE_URL()}
-            ).encode("ascii")
-        ).decode("ascii")
+            ).encode()
+        ).decode()
 
     class Meta:
         verbose_name = _("invite code")

--- a/tests/plugins/federation/test_federation_setup.py
+++ b/tests/plugins/federation/test_federation_setup.py
@@ -15,6 +15,15 @@ def test_create_invitecode(django_app, superuser):
     assert InviteCode.objects.get().url == "https://example.com"
 
 
+def test_federation_oauth_detail_view(django_app, superuser, federation):
+    host, guest = federation
+    django_app.get(
+        reverse("api:settings-oauth-app-detail", args=[host.oauth_application.pk]),
+        user=superuser,
+        status=200,
+    )
+
+
 @patch("ephios.plugins.federation.views.frontend.requests")
 def test_redeem_invitecode_frontend(mock_requests, django_app, superuser, invite_code):
     mock_requests.post.return_value.json.return_value = {

--- a/tests/plugins/federation/test_federation_setup.py
+++ b/tests/plugins/federation/test_federation_setup.py
@@ -15,7 +15,7 @@ def test_create_invitecode(django_app, superuser):
     assert InviteCode.objects.get().url == "https://example.com"
 
 
-@patch("ephios.plugins.federation.forms.requests")
+@patch("ephios.plugins.federation.views.frontend.requests")
 def test_redeem_invitecode_frontend(mock_requests, django_app, superuser, invite_code):
     mock_requests.post.return_value.json.return_value = {
         "host_name": "Test",
@@ -33,7 +33,7 @@ def test_redeem_invitecode_frontend(mock_requests, django_app, superuser, invite
             }
         ).encode("ascii")
     ).decode("ascii")
-    response = form.submit().follow()
+    form.submit().follow()
     assert FederatedHost.objects.count() == 1
 
 

--- a/tests/plugins/federation/test_federation_views.py
+++ b/tests/plugins/federation/test_federation_views.py
@@ -16,14 +16,6 @@ def test_federation_get_shared_events(django_app, volunteer, federation, federat
     assert federated_event.title in response.text
 
 
-def test_federation_oauth_detail_view(django_app, superuser, federation):
-    host, guest = federation
-    response = django_app.get(
-        reverse("api:settings-oauth-app-detail", args=[host.oauth_application.pk]),
-        user=superuser,
-    )
-
-
 @patch("ephios.plugins.federation.views.frontend.requests")
 def test_federation_shared_event_list(
     mock_requests, django_app, volunteer, federation, federated_event, settings

--- a/tests/plugins/federation/test_federation_views.py
+++ b/tests/plugins/federation/test_federation_views.py
@@ -16,6 +16,14 @@ def test_federation_get_shared_events(django_app, volunteer, federation, federat
     assert federated_event.title in response.text
 
 
+def test_federation_oauth_detail_view(django_app, superuser, federation):
+    host, guest = federation
+    response = django_app.get(
+        reverse("api:settings-oauth-app-detail", args=[host.oauth_application.pk]),
+        user=superuser,
+    )
+
+
 @patch("ephios.plugins.federation.views.frontend.requests")
 def test_federation_shared_event_list(
     mock_requests, django_app, volunteer, federation, federated_event, settings


### PR DESCRIPTION
* [x] `get_absolute_url` ist broken wenn du nicht owner der application bist
* [x] den handelnden nutzer gleich mitspeichern wenn man nen invite code redeemed und mir gefällt auch nicht das in der clean_code method der RedeemInviteCodeForm gleich die models erzeugt werden. die business logic gehört nicht in diese funktion, höchstens in ne extra "save" funktion vergleichbar modelforms aber eher noch in ne extra funktion