### PR TITLE
don't send notifications to users with invalid mail address

### DIFF
--- a/ephios/core/services/notifications/backends.py
+++ b/ephios/core/services/notifications/backends.py
@@ -99,7 +99,7 @@ class AbstractNotificationBackend:
     def user_prefers_sending(cls, notification):
         if not notification.user:
             return True
-        if not notification.user.is_active:
+        if not notification.user.is_active or notification.user.email_invalid:
             return False
         if (
             acting_user := notification.data.get("acting_user", None)


### PR DESCRIPTION
self-hosting user had an issue where they marked the email address as invalid in the django-admin interface to disable all notifications for technical reasons while the users should still remain active. 