### PR TITLE
remove importlib-metadata

### DIFF
--- a/ephios/settings.py
+++ b/ephios/settings.py
@@ -3,6 +3,7 @@ import datetime
 import os
 from datetime import timedelta
 from email.utils import getaddresses
+from importlib import metadata
 from pathlib import Path
 
 import environ
@@ -12,11 +13,6 @@ from django.utils.translation import gettext_lazy
 from py_vapid import Vapid, b64urlencode
 
 from ephios.extra.secrets import django_secret_from_file
-
-try:
-    import importlib_metadata  # importlib is broken on python3.8, using backport
-except ImportError:
-    import importlib.metadata as importlib_metadata
 
 # BASE_DIR is the directory containing the ephios package
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
@@ -60,8 +56,8 @@ else:
 ALLOWED_HOSTS = env.list("ALLOWED_HOSTS")
 
 try:
-    EPHIOS_VERSION = importlib_metadata.version("ephios")
-except importlib_metadata.PackageNotFoundError:
+    EPHIOS_VERSION = metadata.version("ephios")
+except metadata.PackageNotFoundError:
     # ephios is not installed as a package (e.g. development setup)
     EPHIOS_VERSION = "dev"
 
@@ -113,7 +109,7 @@ CORE_PLUGINS = [
     "ephios.plugins.federation.apps.PluginApp",
 ]
 PLUGINS = copy.copy(CORE_PLUGINS)
-for ep in importlib_metadata.entry_points(group="ephios.plugins"):
+for ep in metadata.entry_points(group="ephios.plugins"):
     PLUGINS.append(ep.value)
 
 INSTALLED_APPS += PLUGINS

--- a/poetry.lock
+++ b/poetry.lock
@@ -2584,8 +2584,6 @@ files = [
     {file = "psycopg2-2.9.9-cp310-cp310-win_amd64.whl", hash = "sha256:426f9f29bde126913a20a96ff8ce7d73fd8a216cfb323b1f04da402d452853c3"},
     {file = "psycopg2-2.9.9-cp311-cp311-win32.whl", hash = "sha256:ade01303ccf7ae12c356a5e10911c9e1c51136003a9a1d92f7aa9d010fb98372"},
     {file = "psycopg2-2.9.9-cp311-cp311-win_amd64.whl", hash = "sha256:121081ea2e76729acfb0673ff33755e8703d45e926e416cb59bae3a86c6a4981"},
-    {file = "psycopg2-2.9.9-cp312-cp312-win32.whl", hash = "sha256:d735786acc7dd25815e89cc4ad529a43af779db2e25aa7c626de864127e5a024"},
-    {file = "psycopg2-2.9.9-cp312-cp312-win_amd64.whl", hash = "sha256:a7653d00b732afb6fc597e29c50ad28087dcb4fbfb28e86092277a559ae4e693"},
     {file = "psycopg2-2.9.9-cp37-cp37m-win32.whl", hash = "sha256:5e0d98cade4f0e0304d7d6f25bbfbc5bd186e07b38eac65379309c4ca3193efa"},
     {file = "psycopg2-2.9.9-cp37-cp37m-win_amd64.whl", hash = "sha256:7e2dacf8b009a1c1e843b5213a87f7c544b2b042476ed7755be813eaf4e8347a"},
     {file = "psycopg2-2.9.9-cp38-cp38-win32.whl", hash = "sha256:ff432630e510709564c01dafdbe996cb552e0b9f3f065eb89bdce5bd31fabf4c"},
@@ -3884,4 +3882,4 @@ redis = ["redis"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "6ce74abe327738602d4682037c25eff07f7d3d373dcf2e051c08e95e593652d9"
+content-hash = "924ff34bc71b07dbcf63ef09dbae91c9731d83bbec7b2e4a996073811503deee"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,6 @@ django-statici18n = "^2.3.1"
 django-dynamic-preferences = "^1.15.0"
 django-crispy-forms = "^2.0"
 django-webpush = "^0.3.5"
-importlib-metadata = { version = ">=5.2.0", python = "<3.9" }
 django-libsass = "^0.9"
 crispy-bootstrap5 = ">=0.7,<2024.3"
 djangorestframework = "^3.13.1"


### PR DESCRIPTION
the recent updates breaks django: https://stackoverflow.com/questions/78977665/django-autoreload-raises-typeerror-unhashable-type-types-simplenamespace

As we only had it for backwards compatibility to python3.8 which is EOL shortly, we can drop it altogether