### PR TITLE
Fix teams structure fullness display

### DIFF
--- a/ephios/core/signup/stats.py
+++ b/ephios/core/signup/stats.py
@@ -31,6 +31,9 @@ class SignupStats:
     def replace(self, **kwargs):
         return dataclasses.replace(self, **kwargs)
 
+    def has_free(self):
+        return self.free is None or self.free > 0
+
     def __add__(self, other: "SignupStats"):
         free = self.free + other.free if self.free is not None and other.free is not None else None
         missing = self.missing + other.missing

--- a/ephios/plugins/baseshiftstructures/structure/group_common.py
+++ b/ephios/plugins/baseshiftstructures/structure/group_common.py
@@ -84,7 +84,8 @@ class QualificationRequirementForm(forms.Form):
     def clean_max_count(self):
         if (
             self.cleaned_data["max_count"]
-            and self.cleaned_data["max_count"] < self.cleaned_data["min_count"]
+            and (min_count := self.cleaned_data.get("min_count"))
+            and self.cleaned_data["max_count"] < min_count
         ):
             raise ValidationError(_("Max count must not be smaller than min count."))
         return self.cleaned_data["max_count"]


### PR DESCRIPTION
Fixes #1381. Fixes #1382. 

* [x] add discussion points to #1383 

This is just a quick fix. We're unhappy with the inconsistencies in the assignment, fullness-determination and counts between the signup structures and therefore plan to follow up with a design session (considering all possible combinations and scenarios and what behavior we expect of them), a rewrite of much of the logic touched here and user documentation.

(There is for example another bug affecting the "full"-state for atomic blocks in the complex structure, which can't be fixed without a more thoughtful rewrite of the matching algorithms.)

@lukasrad02 feel free to test this. As we discussed in our call, this should fix the issues you're currently having with your events. 