### PR TITLE
Cycle serviceworker cache on user change

### DIFF
--- a/ephios/core/templates/core/serviceworker.js
+++ b/ephios/core/templates/core/serviceworker.js
@@ -33,6 +33,17 @@ self.addEventListener('activate', event => {
     );
 });
 
+self.addEventListener("message", (event) => {
+    if (event.data === "logout") {
+        event.waitUntil(
+            caches.keys().then(cacheNames => {
+                console.log("Clearing cache after logout");
+                return Promise.all(cacheNames.map(cacheName => caches.delete(cacheName)));
+            })
+        );
+    }
+});
+
 async function markResponseAsOffline(response) {
     let content = await response.body.getReader().read().then(r => r.value);
     let body = new TextDecoder().decode(content);

--- a/ephios/core/views/auth.py
+++ b/ephios/core/views/auth.py
@@ -51,7 +51,7 @@ class OIDCInitiateView(RedirectView):
 class OIDCCallbackView(RedirectView):
     def failure_url(self):
         messages.error(self.request, _("Authentication failed."))
-        return settings.LOGIN_URL
+        return reverse("login")
 
     def get_redirect_url(self, *args, **kwargs):
         if "error" in self.request.GET:

--- a/ephios/core/views/pwa.py
+++ b/ephios/core/views/pwa.py
@@ -48,7 +48,17 @@ class ServiceWorkerView(TemplateView):
         context["offline_url"] = reverse("core:pwa_offline")
         # Cache name: we serve /static/ files with a cache first strategy, so
         # we need to use a new cache name when the static files change with a new ephios version.
-        context["cache_name"] = f"ephios-pwa-v{settings.EPHIOS_VERSION}"
+        # Also, we need to start a new cache for every user and permission change.
+        identity = self.request.user.id if self.request.user.is_authenticated else "anonymous"
+        permissions = set(self.request.user.get_all_permissions())
+        if self.request.user.is_superuser:
+            permissions.add("_pwa:superuser")
+        if self.request.user.is_staff:
+            permissions.add("_pwa:staff")
+        permission_hash = hash(tuple(sorted(permissions)))
+        context["cache_name"] = (
+            f"ephios-pwa-v{settings.EPHIOS_VERSION}/{identity}-{permission_hash}"
+        )
         context["static_url"] = settings.STATIC_URL
         context["enable_cache"] = settings.COMPRESS_ENABLED
         return context

--- a/ephios/settings.py
+++ b/ephios/settings.py
@@ -208,7 +208,7 @@ AUTHENTICATION_BACKENDS = [
 
 AUTH_USER_MODEL = "core.UserProfile"
 LOGIN_REDIRECT_URL = "/"
-LOGIN_URL = "core:oidc_login"
+LOGIN_URL = "/accounts/login/"
 PASSWORD_RESET_TIMEOUT = 28 * 24 * 60 * 60  # seconds
 
 # Internationalization

--- a/ephios/static/ephios/js/main.js
+++ b/ephios/static/ephios/js/main.js
@@ -66,13 +66,13 @@ function handleForms(elem) {
                 const oldFormInputs = div.querySelectorAll("input, select, textarea");
                 const formValues = {};
                 oldFormInputs.forEach(input => {
-                    // avoid hidden inputs as that might interfere with csrf/formset management
-                    // beware of selects not having a type attribute
-                    if (input.type !== "hidden") {
-                        // TODO breaks with select2?!
-                        formValues[input.name] = input.value;
+                        // avoid hidden inputs as that might interfere with csrf/formset management
+                        // beware of selects not having a type attribute
+                        if (input.type !== "hidden") {
+                            // TODO breaks with select2?!
+                            formValues[input.name] = input.value;
+                        }
                     }
-                }
                 );
                 div.innerHTML = html;
                 const newFormInputs = div.querySelectorAll("input, select, textarea");
@@ -145,9 +145,18 @@ $(document).ready(function () {
         navigator.serviceWorker.register('/serviceworker.js', {
             scope: '/'
         }).then(function (registration) {
-            console.log('django-pwa: ServiceWorker registration successful with scope: ', registration.scope);
+            console.log('ephios: ServiceWorker registration successful with scope: ', registration.scope);
+            const logoutLink = document.getElementById("logout-link");
+            if (logoutLink) {
+                logoutLink.addEventListener("click", (event) => {
+                    // We use a new cache for every new user and set of permissions, but for that to be secure
+                    // when logging out, that requires loading another ephios page to install a new service worker
+                    // --> so on logout, we explicitly tell the serviceworker to clear its cache
+                    registration.active.postMessage("logout");
+                });
+            }
         }, function (err) {
-            console.log('django-pwa: ServiceWorker registration failed: ', err);
+            console.log('ephios: ServiceWorker registration failed: ', err);
         });
     }
 

--- a/ephios/templates/base.html
+++ b/ephios/templates/base.html
@@ -132,7 +132,7 @@
                                                href="{% url "core:notification_list" %}">{% translate "Notifications" %}</a>
                                             <a class="dropdown-item"
                                                href="{% url "core:settings_personal_data" %}">{% translate "Settings" %}</a>
-                                            <a class="dropdown-item"
+                                            <a class="dropdown-item" id="logout-link"
                                                href="{% url "core:oidc_logout" %}">{% translate "Logout" %}</a>
                                         </div>
                                     </li>


### PR DESCRIPTION
fixes #1400

Decided on varying the cache key depending on the user. The new service worker takes care of deleting the old cache. I'm worried about a new worker not being loaded when logging in via an identity provider though. Can you help me try @jeriox ?