### PR TITLE
add API time filters

### DIFF
--- a/docs/user/events/blocks.rst
+++ b/docs/user/events/blocks.rst
@@ -1,7 +1,7 @@
 Preconfigured shift structures
 ==============================
 
-When configuring a shift, you can choose to use a preconfigured shift structure (see :doc:`user/events/signup`).
+When configuring a shift, you can choose to use a preconfigured shift structure (see :doc:`signup`).
 The blocks can be configured in the editor, which can be reached from the shift edit view.
 
 Adding blocks
@@ -12,7 +12,7 @@ A form for the new block will appear on the left side in the editor. There are t
 
 
 Atomic blocks
-^^^^^^^^^^^^
+^^^^^^^^^^^^^
 
 An atomic block is the smallest unit of a block structure. It has a block name and a list of positions.
 Each position can also be named and has a list of required qualifications. The position can also be marked as optional.
@@ -21,7 +21,7 @@ This can be compared to not setting a maximum number of participants for a shift
 You can also define additional conditions for the block, e.g. that everyone has a drivers license.
 
 Composite blocks
-^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^
 
 Composite blocks are a combination of multiple other blocks, both atomic and composite. After adding a composite block,
 it can be given a name. Then, you can add other blocks to the composite block. This is done by clicking the arrow on one

--- a/ephios/api/filters.py
+++ b/ephios/api/filters.py
@@ -1,5 +1,5 @@
+import django_filters
 from django_filters import FilterSet, IsoDateTimeFilter, ModelChoiceFilter
-from django_filters.rest_framework import FilterSet
 from guardian.shortcuts import get_objects_for_user
 from rest_framework.filters import BaseFilterBackend
 
@@ -12,40 +12,25 @@ class ParticipationPermissionFilter(BaseFilterBackend):
         return queryset.filter(shift__event__in=events)
 
 
+class ShiftPermissionFilter(BaseFilterBackend):
+    def filter_queryset(self, request, queryset, view):
+        events = get_objects_for_user(request.user, "core.view_event")
+        return queryset.filter(event__in=events)
+
+
 class StartEndTimeFilterSet(FilterSet):
-    start_time = IsoDateTimeFilter(field_name="start_time", label="start time")
-    start_time__gt = IsoDateTimeFilter(
-        field_name="start_time", lookup_expr="gt", label="start time greater than"
-    )
-    start_time__gte = IsoDateTimeFilter(
-        field_name="start_time", lookup_expr="gte", label="start time greater than equals"
-    )
-    start_time__lt = IsoDateTimeFilter(
-        field_name="start_time", lookup_expr="lt", label="start time less than"
-    )
-    start_time__lte = IsoDateTimeFilter(
-        field_name="start_time", lookup_expr="lte", label="start time less than equals"
-    )
+    start_time = django_filters.rest_framework.IsoDateTimeFromToRangeFilter(label="start time")
+    end_time = django_filters.rest_framework.IsoDateTimeFromToRangeFilter(label="end time")
 
     start_gte = IsoDateTimeFilter(
-        field_name="start_time", lookup_expr="gte", label="start time greater than equals"
-    )  # deprecated
+        field_name="start_time",
+        lookup_expr="gte",
+        label="start time greater than equals (deprecated, use start_time_after instead)",
+    )
     start_lte = IsoDateTimeFilter(
-        field_name="start_time", lookup_expr="lte", label="start time less than equals"
-    )  # deprecated
-
-    end_time = IsoDateTimeFilter(field_name="end_time", label="end time")
-    end_time__gt = IsoDateTimeFilter(
-        field_name="end_time", lookup_expr="gt", label="end time greater than"
-    )
-    end_time__gte = IsoDateTimeFilter(
-        field_name="end_time", lookup_expr="gte", label="end time greater than equals"
-    )
-    end_time__lt = IsoDateTimeFilter(
-        field_name="end_time", lookup_expr="lt", label="end time less than"
-    )
-    end_time__lte = IsoDateTimeFilter(
-        field_name="end_time", lookup_expr="lte", label="end time less than equals"
+        field_name="start_time",
+        lookup_expr="lte",
+        label="start time less than equals (deprecated, use start_time_before instead)",
     )
 
 

--- a/ephios/api/filters.py
+++ b/ephios/api/filters.py
@@ -1,9 +1,9 @@
-from django_filters import DateTimeFilter, ModelChoiceFilter
+from django_filters import FilterSet, IsoDateTimeFilter, ModelChoiceFilter
 from django_filters.rest_framework import FilterSet
 from guardian.shortcuts import get_objects_for_user
 from rest_framework.filters import BaseFilterBackend
 
-from ephios.core.models import EventType, LocalParticipation
+from ephios.core.models import Event, EventType, LocalParticipation
 
 
 class ParticipationPermissionFilter(BaseFilterBackend):
@@ -12,18 +12,58 @@ class ParticipationPermissionFilter(BaseFilterBackend):
         return queryset.filter(shift__event__in=events)
 
 
-class ParticipationFilterSet(FilterSet):
+class StartEndTimeFilterSet(FilterSet):
+    start_time = IsoDateTimeFilter(field_name="start_time", label="start time")
+    start_time__gt = IsoDateTimeFilter(
+        field_name="start_time", lookup_expr="gt", label="start time greater than"
+    )
+    start_time__gte = IsoDateTimeFilter(
+        field_name="start_time", lookup_expr="gte", label="start time greater than equals"
+    )
+    start_time__lt = IsoDateTimeFilter(
+        field_name="start_time", lookup_expr="lt", label="start time less than"
+    )
+    start_time__lte = IsoDateTimeFilter(
+        field_name="start_time", lookup_expr="lte", label="start time less than equals"
+    )
+
+    start_gte = IsoDateTimeFilter(
+        field_name="start_time", lookup_expr="gte", label="start time greater than equals"
+    )  # deprecated
+    start_lte = IsoDateTimeFilter(
+        field_name="start_time", lookup_expr="lte", label="start time less than equals"
+    )  # deprecated
+
+    end_time = IsoDateTimeFilter(field_name="end_time", label="end time")
+    end_time__gt = IsoDateTimeFilter(
+        field_name="end_time", lookup_expr="gt", label="end time greater than"
+    )
+    end_time__gte = IsoDateTimeFilter(
+        field_name="end_time", lookup_expr="gte", label="end time greater than equals"
+    )
+    end_time__lt = IsoDateTimeFilter(
+        field_name="end_time", lookup_expr="lt", label="end time less than"
+    )
+    end_time__lte = IsoDateTimeFilter(
+        field_name="end_time", lookup_expr="lte", label="end time less than equals"
+    )
+
+
+class ParticipationFilterSet(StartEndTimeFilterSet):
     # we cannot use gettext_lazy as it breaks sphinxcontrib.openapi (https://github.com/sphinx-contrib/openapi/issues/153)
     event_type = ModelChoiceFilter(
         field_name="shift__event__type", label="event type", queryset=EventType.objects.all()
     )
-    start_gte = DateTimeFilter(field_name="start_time", lookup_expr="gte", label="start time after")
-    start_lte = DateTimeFilter(
-        field_name="start_time", lookup_expr="lte", label="start time before"
-    )
-    end_gte = DateTimeFilter(field_name="end_time", lookup_expr="gte", label="end time after")
-    end_lte = DateTimeFilter(field_name="end_time", lookup_expr="lte", label="end time before")
 
     class Meta:
         model = LocalParticipation
         fields = ["state"]
+
+
+class EventFilterSet(StartEndTimeFilterSet):
+
+    class Meta:
+        model = Event
+        fields = [
+            "type",
+        ]

--- a/ephios/api/views/events.py
+++ b/ephios/api/views/events.py
@@ -1,13 +1,12 @@
 import django_filters
 from django.db.models import Max, Min, Prefetch
-from django_filters.filters import IsoDateTimeFilter
-from django_filters.filterset import FilterSet
 from oauth2_provider.contrib.rest_framework import IsAuthenticatedOrTokenHasScope
 from rest_framework import filters, serializers, viewsets
 from rest_framework.permissions import DjangoObjectPermissions
 from rest_framework_guardian import filters as guardian_filters
 
 from ephios.api.fields import ChoiceDisplayField
+from ephios.api.filters import EventFilterSet
 from ephios.core.models import AbstractParticipation, Event, EventType, LocalParticipation, Shift
 from ephios.core.templatetags.settings_extras import make_absolute
 
@@ -80,17 +79,6 @@ class ShiftViewSet(viewsets.ReadOnlyModelViewSet):
     filter_backends = [guardian_filters.ObjectPermissionsFilter]
     required_scopes = ["PUBLIC_READ"]
     queryset = Shift.objects.all()
-
-
-class EventFilterSet(FilterSet):
-    start_time = IsoDateTimeFilter(field_name="start_time", label="start time")
-    end_time = IsoDateTimeFilter(field_name="end_time", label="end time")
-
-    class Meta:
-        model = Event
-        fields = [
-            "type",
-        ]
 
 
 class EventViewSet(viewsets.ReadOnlyModelViewSet):

--- a/ephios/api/views/events.py
+++ b/ephios/api/views/events.py
@@ -1,5 +1,7 @@
 import django_filters
 from django.db.models import Max, Min, Prefetch
+from django_filters.filters import IsoDateTimeFilter
+from django_filters.filterset import FilterSet
 from oauth2_provider.contrib.rest_framework import IsAuthenticatedOrTokenHasScope
 from rest_framework import filters, serializers, viewsets
 from rest_framework.permissions import DjangoObjectPermissions
@@ -80,9 +82,20 @@ class ShiftViewSet(viewsets.ReadOnlyModelViewSet):
     queryset = Shift.objects.all()
 
 
+class EventFilterSet(FilterSet):
+    start_time = IsoDateTimeFilter(field_name="start_time", label="start time")
+    end_time = IsoDateTimeFilter(field_name="end_time", label="end time")
+
+    class Meta:
+        model = Event
+        fields = [
+            "type",
+        ]
+
+
 class EventViewSet(viewsets.ReadOnlyModelViewSet):
     serializer_class = EventSerializer
-    filterset_fields = ["type"]
+    filterset_class = EventFilterSet
     search_fields = ["title", "description", "location"]
     ordering_fields = ["start_time", "end_time", "title"]
     ordering = ("start_time", "end_time")

--- a/ephios/api/views/users.py
+++ b/ephios/api/views/users.py
@@ -103,4 +103,6 @@ class UserParticipationView(viewsets.ReadOnlyModelViewSet):
     required_scopes = ["CONFIDENTIAL_READ"]
 
     def get_queryset(self):
-        return LocalParticipation.objects.filter(user=self.kwargs.get("user"))
+        return LocalParticipation.objects.filter(user=self.kwargs.get("user")).select_related(
+            "shift", "shift__event", "shift__event__type"
+        )

--- a/ephios/plugins/federation/views/api.py
+++ b/ephios/plugins/federation/views/api.py
@@ -15,7 +15,7 @@ from rest_framework.exceptions import PermissionDenied
 from rest_framework.generics import CreateAPIView, DestroyAPIView, ListAPIView
 from rest_framework.permissions import AllowAny
 
-from ephios.api.views.events import EventFilterSet
+from ephios.api.filters import EventFilterSet
 from ephios.core.models import Event, Qualification
 from ephios.plugins.federation.models import FederatedGuest, FederatedUser
 from ephios.plugins.federation.serializers import (

--- a/ephios/plugins/federation/views/frontend.py
+++ b/ephios/plugins/federation/views/frontend.py
@@ -44,7 +44,7 @@ class ExternalEventListView(LoginRequiredMixin, TemplateView):
                 r = requests.get(
                     urljoin(host.url, reverse("federation:shared_event_list_view")),
                     headers={"Authorization": f"Bearer {host.access_token}"},
-                    params={"end_time__gte": (datetime.now() - timedelta(days=14)).isoformat()},
+                    params={"end_time_after": (datetime.now() - timedelta(days=14)).isoformat()},
                     timeout=5,
                 )
                 r.raise_for_status()

--- a/ephios/plugins/federation/views/frontend.py
+++ b/ephios/plugins/federation/views/frontend.py
@@ -44,9 +44,7 @@ class ExternalEventListView(LoginRequiredMixin, TemplateView):
                 r = requests.get(
                     urljoin(host.url, reverse("federation:shared_event_list_view")),
                     headers={"Authorization": f"Bearer {host.access_token}"},
-                    params={
-                        "shifts__end_time__gte": (datetime.now() - timedelta(days=14)).isoformat()
-                    },
+                    params={"end_time__gte": (datetime.now() - timedelta(days=14)).isoformat()},
                     timeout=5,
                 )
                 r.raise_for_status()


### PR DESCRIPTION
* Fixes a federation bug where event duplicates would show up in the shared list
* adds the option to filter events by start and end time e.g.
`GET /api/events/?start_time__gte=2024-04-01T07%3A00%3A00%2B02%3A00`
* use the same filters for participation

* [x] also provide those filters for the ShiftViewSet