### PR TITLE
eventtype badge visual fixes

### DIFF
--- a/ephios/core/templates/core/event_detail.html
+++ b/ephios/core/templates/core/event_detail.html
@@ -98,7 +98,7 @@
                 {{ event.title }}
             </h1>
             <h5 class="card-subtitle mb-2 text-body-secondary fw-bolder lh-base">
-                <span class="me-1 badge eventtype-{{ event.type.pk }}-color">{{ event.type }}</span>
+                <span class="me-1 badge badge-eventtype eventtype-{{ event.type.pk }}-color">{{ event.type }}</span>
                 <span class="text-body-secondary me-1 d-inline-block">
                     <i class="fas fa-map-marker-alt"></i>
                     {{ event.location }}

--- a/ephios/core/templates/core/fragments/event_list_day_mode.html
+++ b/ephios/core/templates/core/fragments/event_list_day_mode.html
@@ -38,7 +38,7 @@
                             {{ event.title }}
                         </span>
                         <br/>
-                        <span class="me-1  badge eventtype-{{ event.type.pk }}-color">{{ event.type }}</span>
+                        <span class="me-1 badge badge-eventtype eventtype-{{ event.type.pk }}-color">{{ event.type }}</span>
                         <span class="text-body-secondary me-1 d-inline-block">
                             <i class="fas fa-map-marker-alt"></i>
                             {{ event.location }}
@@ -70,9 +70,9 @@
                         {% include "core/fragments/shift_header.html" with shift=shift participation=participation hide_date=True %}
                         <div class="card-body">
                             {% if shift.label %}
-                                <span class="fw-bold card-title text-body-secondary mb-0">
+                                <p class="fw-bold text-body-secondary mb-0">
                                     <i class="fas fa-tag"></i> {{ shift.label }}
-                                </span>
+                                </p>
                             {% endif %}
                             {% include shift.structure with own_participation=participation %}
                         </div>

--- a/ephios/core/templates/core/fragments/event_list_list_mode.html
+++ b/ephios/core/templates/core/fragments/event_list_list_mode.html
@@ -32,12 +32,9 @@
                              {% if counter %}
                                  data-bs-toggle="tooltip" data-bs-placement="bottom" data-bs-html="true"
                                  title="{% for state in counter %}<div>
-
-
-
-
-
-                                            {% if event.shifts.all|length > 1 %}{{ counter|get:state }} {% endif %}{{ ParticipationStates.labels_dict|get:state }}</div>{% endfor %}"
+                                            {% if event.shifts.all|length > 1 %}
+                                                {{ counter|get:state }} {% endif %}{{ ParticipationStates.labels_dict|get:state }}
+                                            </div>{% endfor %}"
                              {% endif %}>
                             {% if counter|get:ParticipationStates.CONFIRMED > 0 %}
                                 <span class="text-success fa fa-user-check ps-2"></span>
@@ -71,7 +68,7 @@
                             <a class="grid-badge event-list-item-link" href="{{ event.get_absolute_url }}">
                                 <span class="badge badge-eventtype eventtype-{{ event.type.pk }}-color">{{ event.type }}</span>
                             </a>
-                            <a class="grid-signup d-flex flex-column align-items-end align-items-lg-center justify-content-center event-list-item-link"
+                            <a class="grid-signup d-flex flex-column align-items-end justify-content-center event-list-item-link"
                                href="{{ event.get_absolute_url }}">
                                 <div class="position-relative">
                                     <span class="fas fa-users"></span>

--- a/ephios/core/templates/core/fragments/event_list_list_mode.html
+++ b/ephios/core/templates/core/fragments/event_list_list_mode.html
@@ -64,8 +64,8 @@
                                     {{ event.location }}
                                 </span>
                             </div>
-                            <div class="grid-batch"><span
-                                class="badge eventtype-{{ event.type.pk }}-color">{{ event.type }}</span>
+                            <div class="grid-badge"><span
+                                class="badge badge-eventtype eventtype-{{ event.type.pk }}-color">{{ event.type }}</span>
                             </div>
                             <div class="grid-signup d-flex flex-column align-items-end align-items-lg-center justify-content-center">
                                 <div class="position-relative">

--- a/ephios/core/templates/core/fragments/event_list_list_mode.html
+++ b/ephios/core/templates/core/fragments/event_list_list_mode.html
@@ -1,5 +1,5 @@
-{% load i18n %}
 {% load event_extras %}
+{% load i18n %}
 {% load utils %}
 
 <form id="bulk_action_form" method="post">
@@ -32,6 +32,11 @@
                              {% if counter %}
                                  data-bs-toggle="tooltip" data-bs-placement="bottom" data-bs-html="true"
                                  title="{% for state in counter %}<div>
+
+
+
+
+
                                             {% if event.shifts.all|length > 1 %}{{ counter|get:state }} {% endif %}{{ ParticipationStates.labels_dict|get:state }}</div>{% endfor %}"
                              {% endif %}>
                             {% if counter|get:ParticipationStates.CONFIRMED > 0 %}
@@ -53,21 +58,21 @@
                             </div>
                         {% endif %}
                     </div>
-                    <a class="w-100 py-2 text-reset event-list-item-link"
-                       href="{{ event.get_absolute_url }}">
+                    <div class="w-100 py-2 event-list-item">
                         <div class="grid-wrapper m-0 py-0 ps-2 pe-3">
-                            <div class="grid-title">
+                            <a class="grid-title event-list-item-link" href="{{ event.get_absolute_url }}">
                                 <h5 class="mb-0 text-break">
                                     {{ event.title }}
                                 </h5>
                                 <span class="w-100 text-body-secondary text-break">
                                     {{ event.location }}
                                 </span>
-                            </div>
-                            <div class="grid-badge"><span
-                                class="badge badge-eventtype eventtype-{{ event.type.pk }}-color">{{ event.type }}</span>
-                            </div>
-                            <div class="grid-signup d-flex flex-column align-items-end align-items-lg-center justify-content-center">
+                            </a>
+                            <a class="grid-badge event-list-item-link" href="{{ event.get_absolute_url }}">
+                                <span class="badge badge-eventtype eventtype-{{ event.type.pk }}-color">{{ event.type }}</span>
+                            </a>
+                            <a class="grid-signup d-flex flex-column align-items-end align-items-lg-center justify-content-center event-list-item-link"
+                               href="{{ event.get_absolute_url }}">
                                 <div class="position-relative">
                                     <span class="fas fa-users"></span>
                                     {% if event.pending_disposition_count %}
@@ -78,8 +83,8 @@
                                 <div>
                                     {% include "core/fragments/signup_stats_indicator.html" with stats=stats %}
                                 </div>
-                            </div>
-                            <div class="grid-time">
+                            </a>
+                            <a class="grid-time event-list-item-link" href="{{ event.get_absolute_url }}">
                                 {{ event.start_time|date:"D" }},
                                 {% if event.start_time.date == event.end_time.date %}
                                     {{ event.start_time|date:"SHORT_DATE_FORMAT" }}
@@ -93,14 +98,11 @@
                                     {% translate "to" %}
                                     {{ event.end_time|date:"SHORT_DATE_FORMAT" }}
                                 {% endif %}
-                            </div>
+                            </a>
                             <div class="grid-action d-none d-lg-flex flex-column justify-content-center">
-                                <div class="btn btn-outline-primary text-nowrap event-list-item-button">
-                                    <span class="fa fa-eye"></span> {% translate "Show" %}
-                                </div>
                             </div>
                         </div>
-                    </a>
+                    </div>
                 </li>
             {% endwith %}
         {% empty %}

--- a/ephios/core/templates/core/home.html
+++ b/ephios/core/templates/core/home.html
@@ -19,7 +19,7 @@
     <h1 class="page-header">
         {% blocktranslate trimmed with organization_name=global_preferences.general__organization_name %}
             Welcome to {{ organization_name }}!
-        {% endblocktranslate%}
+        {% endblocktranslate %}
     </h1>
 
     <style nonce="{{ request.csp_nonce }}">
@@ -44,9 +44,7 @@
                                 <div class="row">
                                     <span class="col col-lg-6 text-break">
                                         {{ participation.shift.event.title }}
-                                    </span>
-                                    <span class="col-auto col-lg-2">
-                                        <span class="badge eventtype-{{ participation.shift.event.type.pk }}-color">{{ participation.shift.event.type }}</span>
+                                        <span class="float-end badge badge-eventtype eventtype-{{ participation.shift.event.type.pk }}-color">{{ participation.shift.event.type }}</span>
                                     </span>
                                     <span class="col-lg-4">
                                         {{ participation.start_time|date:"D" }}, {{ participation.start_time|date:"SHORT_DATE_FORMAT" }}, {{ participation.get_time_display }}
@@ -64,7 +62,8 @@
                 {% empty %}
                     <li class="list-group-item d-flex flex-column align-items-center justify-content-center">
                         <span class="pb-1 text-body-secondary">{% translate "None yet" context "empty list of upcoming shifts" %}</span>
-                        <a class="btn btn-sm btn-primary" href="{% url "core:event_list" %}">{% translate "View events" %}</a>
+                        <a class="btn btn-sm btn-primary"
+                           href="{% url "core:event_list" %}">{% translate "View events" %}</a>
                     </li>
 
                 {% endfor %}
@@ -87,11 +86,9 @@
                                 </div>
                                 <div class="col">
                                     <div class="row">
-                                        <span class="col col-lg-6 text-break">
+                                        <span class="col col-lg-8 text-break">
                                             {{ shift.event.title }}
-                                        </span>
-                                        <span class="col-auto col-lg-2">
-                                            <span class="badge eventtype-{{ shift.event.type.pk }}-color">{{ shift.event.type }}</span>
+                                            <span class="float-end badge badge-eventtype eventtype-{{ shift.event.type.pk }}-color">{{ shift.event.type }}</span>
                                         </span>
                                         <span class="col-lg-4">
                                             {{ shift.start_time|date:"D" }}, {{ shift.start_time|date:"SHORT_DATE_FORMAT" }}, {{ shift.get_time_display }}

--- a/ephios/plugins/federation/templates/federation/external_event_list.html
+++ b/ephios/plugins/federation/templates/federation/external_event_list.html
@@ -47,7 +47,7 @@
                                 {{ event.location }}
                             </span>
                         </div>
-                        <div class="grid-batch"><span
+                        <div class="grid-badge"><span
                             class="badge bg-primary">{{ event.type }}</span>
                         </div>
                         <div class="grid-signup">

--- a/ephios/plugins/federation/templates/federation/external_event_list.html
+++ b/ephios/plugins/federation/templates/federation/external_event_list.html
@@ -24,16 +24,15 @@
     <h1>{% translate "External events" %}</h1>
     <ul class="list-group mb-3">
         {% for event in events %}
-            <li class="list-group-item list-group-item-action p-0 d-flex flex-row">
+            <li class="list-group-item p-0 d-flex flex-row">
                 <div class="m-0 py-2 d-flex flex-column flex-lg-row-reverse justify-content-around flex-grow-0">
                     <div class="ps-lg-2 d-flex flex-row flex-lg-column justify-content-center event-list-status-icon">
-                        <span class="text-muted far fa-user ps-2"></span>
+                        <span class="text-body-secondary far fa-user ps-2"></span>
                     </div>
                 </div>
-                <a class="w-100 text-reset py-2 event-list-item-link"
-                   href="{{ event.signup_url }}">
+                <div class="w-100 py-2 event-list-item">
                     <div class="grid-wrapper m-0 py-0 ps-2 pe-3">
-                        <div class="grid-title">
+                        <a class="grid-title event-list-item-link" href="{{ event.signup_url }}">
                             <div>
                                 <h5 class="mb-0 text-break d-inline-block">
                                     {{ event.title }}
@@ -43,16 +42,17 @@
                                     <span class="">{{ event.host }}</span>
                                 </small>
                             </div>
-                            <span class="w-100 text-muted text-break">
+                            <span class="w-100 text-body-secondary text-break">
                                 {{ event.location }}
                             </span>
-                        </div>
-                        <div class="grid-badge"><span
-                            class="badge bg-primary">{{ event.type }}</span>
-                        </div>
-                        <div class="grid-signup">
-                        </div>
-                        <div class="grid-time">
+                        </a>
+                        <a class="grid-badge event-list-item-link" href="{{ event.signup_url }}">
+                            <span class="badge badge-eventtype bg-primary">{{ event.type }}</span>
+                        </a>
+                        <a class="grid-signup d-flex flex-column align-items-end justify-content-center event-list-item-link"
+                           href="{{ event.signup_url }}">
+                        </a>
+                        <a class="grid-time event-list-item-link" href="{{ event.signup_url }}">
                             {{ event.start_time|date:"D" }},
                             {% if event.start_time.date == event.end_time.date %}
                                 {{ event.start_time|date:"SHORT_DATE_FORMAT" }}
@@ -66,14 +66,11 @@
                                 {% translate "to" %}
                                 {{ event.end_time|date:"SHORT_DATE_FORMAT" }}
                             {% endif %}
-                        </div>
+                        </a>
                         <div class="grid-action d-none d-lg-flex flex-column justify-content-center">
-                            <div class="btn btn-outline-primary text-nowrap event-list-item-button">
-                                <span class="fa fa-eye"></span> {% translate "Show" %}
-                            </div>
                         </div>
                     </div>
-                </a>
+                </div>
             </li>
         {% empty %}
             <div class="mb-3">

--- a/ephios/static/ephios/scss/ephios_custom.scss
+++ b/ephios/static/ephios/scss/ephios_custom.scss
@@ -99,27 +99,19 @@ footer {
   border-color: #0000;
 }
 
-/* Make the event list item unclickable on large devices, as we want users to use the button there (hence it's excluded) */
-@media (min-width: 992px) {
-  .event-list-item-link {
-    pointer-events: none;
-  }
-
-  .event-list-item-button {
-    pointer-events: auto;
-  }
-}
-
 .event-list-item-link {
+  // remove link style (.text-reset)
   text-decoration: none;
+  --bs-text-opacity: 1;
+  color: inherit !important;
 }
 
 /* event list layout */
 
-.event-list-item-link {
+.event-list-item {
   .grid-wrapper {
     display: grid;
-    grid-column-gap: 0.5rem;
+    grid-column-gap: 0;
     grid-template-columns: 1fr auto;
     grid-template-rows: auto;
     grid-template-areas:
@@ -134,18 +126,24 @@ footer {
 
   .grid-time {
     grid-area: time;
+    width: 100%;
+    @media (min-width: 992px) {
+      padding-left: 0.5rem;
+    }
   }
 
   .grid-badge {
     grid-area: badge;
     justify-self: end;
     max-width: 33vw;
+    padding-left: 0.5rem;
   }
 
   .grid-signup {
     grid-area: signup;
     justify-self: end;
     align-self: end;
+    width: 100%;
   }
 
   .grid-action {

--- a/ephios/static/ephios/scss/ephios_custom.scss
+++ b/ephios/static/ephios/scss/ephios_custom.scss
@@ -1,3 +1,7 @@
+body {
+  hyphens: auto;
+}
+
 header {
   position: sticky;
   top: 0;
@@ -119,7 +123,7 @@ footer {
     grid-template-columns: 1fr auto;
     grid-template-rows: auto;
     grid-template-areas:
-      "title batch"
+      "title badge"
       "title signup"
       "time signup";
   }
@@ -132,9 +136,10 @@ footer {
     grid-area: time;
   }
 
-  .grid-batch {
-    grid-area: batch;
+  .grid-badge {
+    grid-area: badge;
     justify-self: end;
+    max-width: 33vw;
   }
 
   .grid-signup {
@@ -153,7 +158,7 @@ footer {
       grid-template-columns: 6fr auto 8rem 6rem auto;
       grid-template-rows: auto;
       grid-template-areas:
-        "title batch time signup action"
+        "title badge time signup action"
     }
     .grid-signup {
       justify-self: center;
@@ -211,6 +216,15 @@ a.badge {
 .badge-participant {
   max-width: 100%;
   overflow: clip;
+  text-overflow: ellipsis;
+}
+
+// eventtype badge
+
+.badge-eventtype {
+  overflow: clip;
+  text-overflow: ellipsis;
+  max-width: 100%;
 }
 
 // show form feedback

--- a/ephios/static/ephios/scss/ephios_custom.scss
+++ b/ephios/static/ephios/scss/ephios_custom.scss
@@ -153,7 +153,7 @@ footer {
 
   @media (min-width: 992px) {
     .grid-wrapper {
-      grid-template-columns: 6fr auto 8rem 6rem auto;
+      grid-template-columns: 6fr auto 8rem 5rem auto;
       grid-template-rows: auto;
       grid-template-areas:
         "title badge time signup action"


### PR DESCRIPTION
Create  a new eventtype with a long title and you'll see visual glitches on the homepage and the event list, esp. on small screens.
This doesn't make it perfect, but it is an improvement I would say. Please try various event type name lengths and various viewport widths.

* [x] Close #1220
* [x]  check external event list