### PR TITLE
fix event change permission check

### DIFF
--- a/ephios/core/templates/core/event_detail.html
+++ b/ephios/core/templates/core/event_detail.html
@@ -4,7 +4,6 @@
 {% load event_extras %}
 {% load bootstrap %}
 {% load rich_text %}
-{% load guardian_tags %}
 {% load i18n %}
 
 {% block title %}

--- a/ephios/core/templates/core/event_detail.html
+++ b/ephios/core/templates/core/event_detail.html
@@ -20,9 +20,6 @@
 {% endblock %}
 
 {% block content %}
-    {% if request.user.is_authenticated %}
-        {% get_obj_perms request.user for event as "event_perms" %}
-    {% endif %}
     {% if not event.active %}
         {% if event.shifts.exists %}
             {% translate "This event has not been saved! If you are done editing the event, you can save it." as not_active_error %}
@@ -40,7 +37,7 @@
     <div class="card mb-3">
         <div class="card-body pb-0">
             <h1 class="card-title fw-bold fs-1">
-                {% if "change_event" in event_perms %}
+                {% if can_change_event %}
                     <div class="dropstart float-end">
                         <button class="btn" type="button" id="actionDropdownButton"
                                 data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">

--- a/ephios/core/views/event.py
+++ b/ephios/core/views/event.py
@@ -450,6 +450,12 @@ class EventDetailView(CustomPermissionRequiredMixin, CanonicalSlugDetailMixin, D
             base = Event.all_objects.all()
         return base.prefetch_related("shifts", "shifts__participations")
 
+    def get_context_data(self, **kwargs):
+        kwargs["can_change_event"] = self.object in get_objects_for_user(
+            self.request.user, "core.change_event"
+        )
+        return super().get_context_data(**kwargs)
+
 
 class EventUpdateView(CustomPermissionRequiredMixin, PluginFormMixin, UpdateView):
     model = Event

--- a/ephios/core/views/event.py
+++ b/ephios/core/views/event.py
@@ -451,9 +451,7 @@ class EventDetailView(CustomPermissionRequiredMixin, CanonicalSlugDetailMixin, D
         return base.prefetch_related("shifts", "shifts__participations")
 
     def get_context_data(self, **kwargs):
-        kwargs["can_change_event"] = self.object in get_objects_for_user(
-            self.request.user, "core.change_event"
-        )
+        kwargs["can_change_event"] = self.request.user.has_perm("core.change_event", self.object)
         return super().get_context_data(**kwargs)
 
 

--- a/ephios/modellogging/recorders.py
+++ b/ephios/modellogging/recorders.py
@@ -10,8 +10,6 @@ from django.template.defaultfilters import yesno
 from django.utils.translation import gettext_lazy as _
 from guardian.shortcuts import get_users_with_perms
 
-from ephios.extra.permissions import get_groups_with_perms
-
 # pylint: disable=protected-access
 
 
@@ -304,6 +302,8 @@ class PermissionLogRecorder(BaseLogRecorder):
         self.label = label
 
     def attached(self, instance):
+        from ephios.extra.permissions import get_groups_with_perms
+
         self.old_users = set(
             get_users_with_perms(
                 instance, with_group_users=False, only_with_perms_in=[self.codename]
@@ -312,6 +312,8 @@ class PermissionLogRecorder(BaseLogRecorder):
         self.old_groups = set(get_groups_with_perms(instance, only_with_perms_in=[self.codename]))
 
     def record(self, action: InstanceActionType, instance):
+        from ephios.extra.permissions import get_groups_with_perms
+
         self.new_users = set(
             get_users_with_perms(
                 instance, with_group_users=False, only_with_perms_in=[self.codename]

--- a/ephios/settings.py
+++ b/ephios/settings.py
@@ -202,7 +202,7 @@ AUTH_PASSWORD_VALIDATORS = [
 ]
 
 AUTHENTICATION_BACKENDS = [
-    "django.contrib.auth.backends.ModelBackend",
+    "ephios.extra.permissions.ObjectSupportingModelBackend",
     "guardian.backends.ObjectPermissionBackend",
     "ephios.extra.auth.EphiosOIDCAB",
 ]

--- a/tests/core/test_event_detail.py
+++ b/tests/core/test_event_detail.py
@@ -38,3 +38,20 @@ def test_show_disposition_button(django_app, volunteer, planner, event):
             user=planner,
         ).follow()
     )
+
+
+def test_edit_permissions(django_app, volunteer, manager, groups, event):
+    assert (
+        "Add another shift"
+        not in django_app.get(
+            reverse("core:event_detail", kwargs=dict(pk=event.pk, slug="nottheactualslug")),
+            user=volunteer,
+        ).follow()
+    )
+    assert (
+        "Add another shift"
+        in django_app.get(
+            reverse("core:event_detail", kwargs=dict(pk=event.pk, slug="nottheactualslug")),
+            user=manager,
+        ).follow()
+    )


### PR DESCRIPTION
So that really annoys me: All the `get_perms` and `has_perm` functions, if used with an `obj`, don't seem to regard the non-object permissions. So if a user was in a management group and had general `change_event` permissions without having `change_event` for a particular event, it would never get recognized. This way it does.
Should we built our own version of those functions? Seems complicated to get into sadly: would require us to roll our own `ObjectPermissionChecker` and everything that stems from it :/