### PR TITLE
Convert shift date into correct timezone

### DIFF
--- a/ephios/core/views/shift.py
+++ b/ephios/core/views/shift.py
@@ -183,7 +183,7 @@ class ShiftUpdateView(
             self.request.POST or None,
             instance=self.object,
             initial={
-                "date": self.object.meeting_time.date(),
+                "date": self.object.meeting_time.astimezone(get_default_timezone()).date(),
                 "meeting_time": self.object.meeting_time.astimezone(get_default_timezone()).time(),
                 "start_time": self.object.start_time.astimezone(get_default_timezone()).time(),
                 "end_time": self.object.end_time.astimezone(get_default_timezone()).time(),


### PR DESCRIPTION
Closes #1450

When debugging above issue, I noticed that the shift dates are saved in UTC on the server. When rendering the update view, the times are converted into the correct time zone, but the date is not.