### PR TITLE
add responsible indicator

### DIFF
--- a/ephios/core/models/events.py
+++ b/ephios/core/models/events.py
@@ -81,7 +81,7 @@ class Event(Model):
     active = BooleanField(default=False, verbose_name=_("active"))
     group_object_permission_set = GenericRelation(
         GroupObjectPermission, object_id_field="object_pk"
-    )
+    )  # GenericRelation allows us to query Groups that have object permissions for this model in a prefetch
 
     objects = ActiveManager()
     all_objects = Manager()

--- a/ephios/core/models/events.py
+++ b/ephios/core/models/events.py
@@ -2,6 +2,7 @@ import logging
 from datetime import timedelta
 from typing import TYPE_CHECKING
 
+from django.contrib.contenttypes.fields import GenericRelation
 from django.db import models, transaction
 from django.db.models import (
     BooleanField,
@@ -24,7 +25,7 @@ from django.utils.timezone import localtime
 from django.utils.translation import gettext_lazy as _
 from django.utils.translation import pgettext
 from dynamic_preferences.models import PerInstancePreferenceModel
-from guardian.shortcuts import assign_perm, get_objects_for_user
+from guardian.shortcuts import assign_perm, get_objects_for_user, GroupObjectPermission
 from polymorphic.managers import PolymorphicManager
 from polymorphic.models import PolymorphicModel
 from polymorphic.query import PolymorphicQuerySet
@@ -78,6 +79,9 @@ class Event(Model):
     location = CharField(_("location"), max_length=254)
     type = ForeignKey(EventType, on_delete=models.CASCADE, verbose_name=_("event type"))
     active = BooleanField(default=False, verbose_name=_("active"))
+    group_object_permission_set = GenericRelation(
+        GroupObjectPermission, object_id_field="object_pk"
+    )
 
     objects = ActiveManager()
     all_objects = Manager()

--- a/ephios/core/models/events.py
+++ b/ephios/core/models/events.py
@@ -25,7 +25,7 @@ from django.utils.timezone import localtime
 from django.utils.translation import gettext_lazy as _
 from django.utils.translation import pgettext
 from dynamic_preferences.models import PerInstancePreferenceModel
-from guardian.shortcuts import assign_perm, get_objects_for_user, GroupObjectPermission
+from guardian.shortcuts import GroupObjectPermission, assign_perm, get_objects_for_user
 from polymorphic.managers import PolymorphicManager
 from polymorphic.models import PolymorphicModel
 from polymorphic.query import PolymorphicQuerySet

--- a/ephios/core/templates/core/event_detail.html
+++ b/ephios/core/templates/core/event_detail.html
@@ -120,6 +120,17 @@
             <div class="card-text text-body-secondary">
                 {{ event.description|rich_text:"h1,h2" }}
             </div>
+            {% if can_change_event %}
+                <div class="card-text text-body-secondary mb-2">
+                    {% if not event|viewable_by:True %}
+                        <i class="fas fa-eye-slash text-warning"></i>
+                        {% translate "Event has not been made visible to any groups." %}
+                    {% else %}
+                        <i class="fas fa-eye"></i>
+                        {% translate "Viewable by" %} {{ event|viewable_by:True }}.
+                    {% endif %}
+                </div>
+            {% endif %}
             <div class="event-plugin-content">
                 {% event_plugin_content event request as plugin_content %}
                 {% for item in plugin_content %}

--- a/ephios/core/templates/core/event_detail.html
+++ b/ephios/core/templates/core/event_detail.html
@@ -122,12 +122,12 @@
             </div>
             {% if can_change_event %}
                 <div class="card-text text-body-secondary mb-2">
-                    {% if not event|viewable_by:True %}
+                    {% if not visible_for %}
                         <i class="fas fa-eye-slash text-warning"></i>
                         {% translate "Event has not been made visible to any groups." %}
                     {% else %}
                         <i class="fas fa-eye"></i>
-                        {% translate "Viewable by" %} {{ event|viewable_by:True }}.
+                        {% translate "Viewable by" %} {{ visible_for }}.
                     {% endif %}
                 </div>
             {% endif %}

--- a/ephios/core/templates/core/fragments/event_list_list_mode.html
+++ b/ephios/core/templates/core/fragments/event_list_list_mode.html
@@ -28,25 +28,37 @@
             {% with counter=event|event_list_signup_state_counts stats=event.get_signup_stats %}
                 <li class="list-group-item p-0 d-flex flex-row">
                     <div class="m-0 py-2 d-flex flex-column flex-lg-row-reverse justify-content-around flex-grow-0">
-                        <div class="ps-lg-2 d-flex flex-row flex-lg-column justify-content-center event-list-status-icon"
-                             {% if counter %}
-                                 data-bs-toggle="tooltip" data-bs-placement="bottom" data-bs-html="true"
-                                 title="{% for state in counter %}<div>
-                                            {% if event.shifts.all|length > 1 %}
-                                                {{ counter|get:state }} {% endif %}{{ ParticipationStates.labels_dict|get:state }}
-                                            </div>{% endfor %}"
-                             {% endif %}>
-                            {% if counter|get:ParticipationStates.CONFIRMED > 0 %}
-                                <span class="text-success fa fa-user-check ps-2"></span>
-                            {% elif counter|get:ParticipationStates.REQUESTED > 0 %}
-                                <span class="text-warning fa fa-user-clock ps-2"></span>
-                            {% elif counter|get:ParticipationStates.RESPONSIBLE_REJECTED > 0 %}
-                                <span class="text-danger fa fa-user-times ps-2"></span>
-                            {% elif counter|get:ParticipationStates.USER_DECLINED > 0 and counter|length == 1 %}
-                                <span class="text-danger fa fa-user-minus ps-2"></span>
-                            {% else %}
-                                <span class="text-body-secondary far fa-user ps-2"></span>
+                        <div class="ps-lg-2 d-flex flex-column justify-content-center">
+                            {% if event.can_change %}
+                                <small class="text-body-secondary" data-bs-toggle="tooltip" data-bs-placement="top"
+                                       title="{% for perm in event.view_permissions %}
+                                                  {{ perm.group.name }}{% if not forloop.last %}, {% endif %}
+                                              {% empty %}
+                                                  {% translate "Invisible" %}
+                                              {% endfor %}">
+                                    <i class="ps-2 fas fa-eye{% if not event.view_permissions %}-slash{% endif %}"></i>
+                                </small>
                             {% endif %}
+                            <span class=""
+                                  {% if counter %}
+                                      data-bs-toggle="tooltip" data-bs-placement="bottom" data-bs-html="true"
+                                      title="{% for state in counter %}<div>
+                                                 {% if event.shifts.all|length > 1 %}
+                                                     {{ counter|get:state }} {% endif %}{{ ParticipationStates.labels_dict|get:state }}
+                                                 </div>{% endfor %}"
+                                  {% endif %}>
+                                {% if counter|get:ParticipationStates.CONFIRMED > 0 %}
+                                    <i class="text-success fa fa-user-check ps-2"></i>
+                                {% elif counter|get:ParticipationStates.REQUESTED > 0 %}
+                                    <i class="text-warning fa fa-user-clock ps-2"></i>
+                                {% elif counter|get:ParticipationStates.RESPONSIBLE_REJECTED > 0 %}
+                                    <i class="text-danger fa fa-user-times ps-2"></i>
+                                {% elif counter|get:ParticipationStates.USER_DECLINED > 0 and counter|length == 1 %}
+                                    <i class="text-danger fa fa-user-minus ps-2"></i>
+                                {% else %}
+                                    <i class="text-body-secondary far fa-user ps-2"></i>
+                                {% endif %}
+                            </span>
                         </div>
                         {% if perms.core.add_event %}
                             <div class="ps-lg-2 d-flex flex-row flex-lg-column justify-content-center">
@@ -68,17 +80,9 @@
                             <a class="grid-badge event-list-item-link" href="{{ event.get_absolute_url }}">
                                 <span class="badge badge-eventtype eventtype-{{ event.type.pk }}-color">{{ event.type }}</span>
                             </a>
-                            <a class="grid-signup d-flex flex-row justify-content-between event-list-item-link"
+                            <a class="grid-signup d-flex flex-row justify-content-end event-list-item-link w-100"
                                href="{{ event.get_absolute_url }}">
-                                <div class="px-1">
-                                    {% if event.can_change %}
-                                        <small class="pe-1" data-bs-toggle="tooltip" data-bs-placement="left"
-                                               title="{% translate "Responsible" %}">
-                                            <i class="fas fa-crown text-body-secondary"></i>
-                                        </small>
-                                    {% endif %}
-                                </div>
-                                <div class="d-flex flex-column align-items-end justify-content-center ">
+                                <div class="d-flex flex-column align-items-end justify-content-center">
                                     <div class="position-relative">
                                         <span class="fas fa-users"></span>
                                         {% if event.pending_disposition_count %}

--- a/ephios/core/templates/core/fragments/event_list_list_mode.html
+++ b/ephios/core/templates/core/fragments/event_list_list_mode.html
@@ -66,41 +66,47 @@
                                 </span>
                             </a>
                             <a class="grid-badge event-list-item-link" href="{{ event.get_absolute_url }}">
-                                {% if event.can_change %}
-                                    <small class="pe-1" data-bs-toggle="tooltip" data-bs-placement="left"
-                                           title="{% translate "Responsible" %}">
-                                        <i class="fas fa-crown text-body-secondary"></i>
-                                    </small>
-                                {% endif %}
                                 <span class="badge badge-eventtype eventtype-{{ event.type.pk }}-color">{{ event.type }}</span>
                             </a>
-                            <a class="grid-signup d-flex flex-column align-items-end justify-content-center event-list-item-link"
+                            <a class="grid-signup d-flex flex-row justify-content-between event-list-item-link"
                                href="{{ event.get_absolute_url }}">
-                                <div class="position-relative">
-                                    <span class="fas fa-users"></span>
-                                    {% if event.pending_disposition_count %}
-                                        <span class="pending-indicator"></span>
+                                <div class="px-1">
+                                    {% if event.can_change %}
+                                        <small class="pe-1" data-bs-toggle="tooltip" data-bs-placement="left"
+                                               title="{% translate "Responsible" %}">
+                                            <i class="fas fa-crown text-body-secondary"></i>
+                                        </small>
                                     {% endif %}
-                                    {{ stats.confirmed_count }}
                                 </div>
-                                <div>
-                                    {% include "core/fragments/signup_stats_indicator.html" with stats=stats %}
+                                <div class="d-flex flex-column align-items-end justify-content-center ">
+                                    <div class="position-relative">
+                                        <span class="fas fa-users"></span>
+                                        {% if event.pending_disposition_count %}
+                                            <span class="pending-indicator"></span>
+                                        {% endif %}
+                                        {{ stats.confirmed_count }}
+                                    </div>
+                                    <div>
+                                        {% include "core/fragments/signup_stats_indicator.html" with stats=stats %}
+                                    </div>
                                 </div>
                             </a>
                             <a class="grid-time event-list-item-link" href="{{ event.get_absolute_url }}">
-                                {{ event.start_time|date:"D" }},
-                                {% if event.start_time.date == event.end_time.date %}
-                                    {{ event.start_time|date:"SHORT_DATE_FORMAT" }}
-                                    <span class="d-lg-none">,</span>
-                                    <span class="d-none d-lg-inline"><br></span>
-                                    {{ event.start_time|date:"TIME_FORMAT" }} –
-                                    {{ event.end_time|date:"TIME_FORMAT" }}
-                                {% else %}
-                                    {{ event.start_time|date:"SHORT_DATE_FORMAT" }}
-                                    <span class="d-none d-lg-inline"><br></span>
-                                    {% translate "to" %}
-                                    {{ event.end_time|date:"SHORT_DATE_FORMAT" }}
-                                {% endif %}
+                                <div>
+                                    {{ event.start_time|date:"D" }},
+                                    {% if event.start_time.date == event.end_time.date %}
+                                        {{ event.start_time|date:"SHORT_DATE_FORMAT" }}
+                                        <span class="d-lg-none">,</span>
+                                        <span class="d-none d-lg-inline"><br></span>
+                                        {{ event.start_time|date:"TIME_FORMAT" }} –
+                                        {{ event.end_time|date:"TIME_FORMAT" }}
+                                    {% else %}
+                                        {{ event.start_time|date:"SHORT_DATE_FORMAT" }}
+                                        <span class="d-none d-lg-inline"><br></span>
+                                        {% translate "to" %}
+                                        {{ event.end_time|date:"SHORT_DATE_FORMAT" }}
+                                    {% endif %}
+                                </div>
                             </a>
                             <div class="grid-action d-none d-lg-flex flex-column justify-content-center">
                             </div>

--- a/ephios/core/templates/core/fragments/event_list_list_mode.html
+++ b/ephios/core/templates/core/fragments/event_list_list_mode.html
@@ -28,19 +28,8 @@
             {% with counter=event|event_list_signup_state_counts stats=event.get_signup_stats %}
                 <li class="list-group-item p-0 d-flex flex-row">
                     <div class="m-0 py-2 d-flex flex-column flex-lg-row-reverse justify-content-around flex-grow-0">
-                        <div class="ps-lg-2 d-flex flex-column justify-content-center">
-                            {% if event.can_change %}
-                                <small class="text-body-secondary" data-bs-toggle="tooltip" data-bs-placement="top"
-                                       title="{% for perm in event.view_permissions %}
-                                                  {{ perm.group.name }}{% if not forloop.last %}, {% endif %}
-                                              {% empty %}
-                                                  {% translate "Invisible" %}
-                                              {% endfor %}">
-                                    <i class="ps-2 fas fa-eye{% if not event.view_permissions %}-slash{% endif %}"></i>
-                                </small>
-                            {% endif %}
-                            <span class=""
-                                  {% if counter %}
+                        <div class="ps-lg-2 d-flex flex-column justify-content-center event-list-status-icon">
+                            <span {% if counter %}
                                       data-bs-toggle="tooltip" data-bs-placement="bottom" data-bs-html="true"
                                       title="{% for state in counter %}<div>
                                                  {% if event.shifts.all|length > 1 %}
@@ -48,15 +37,15 @@
                                                  </div>{% endfor %}"
                                   {% endif %}>
                                 {% if counter|get:ParticipationStates.CONFIRMED > 0 %}
-                                    <i class="text-success fa fa-user-check ps-2"></i>
+                                    <i class="text-{% if event.can_change %}info{% else %}success{% endif %} fa fa-user-check ps-2"></i>
                                 {% elif counter|get:ParticipationStates.REQUESTED > 0 %}
-                                    <i class="text-warning fa fa-user-clock ps-2"></i>
+                                    <i class="text-{% if event.can_change %}info{% else %}warning{% endif %} fa fa-user-clock ps-2"></i>
                                 {% elif counter|get:ParticipationStates.RESPONSIBLE_REJECTED > 0 %}
-                                    <i class="text-danger fa fa-user-times ps-2"></i>
+                                    <i class="text-{% if event.can_change %}info{% else %}danger{% endif %} fa fa-user-times ps-2"></i>
                                 {% elif counter|get:ParticipationStates.USER_DECLINED > 0 and counter|length == 1 %}
-                                    <i class="text-danger fa fa-user-minus ps-2"></i>
+                                    <i class="text-{% if event.can_change %}info{% else %}danger{% endif %} fa fa-user-minus ps-2"></i>
                                 {% else %}
-                                    <i class="text-body-secondary far fa-user ps-2"></i>
+                                    <i class="text-{% if event.can_change %}info{% else %}body-secondary{% endif %} far fa-user ps-2"></i>
                                 {% endif %}
                             </span>
                         </div>
@@ -83,12 +72,34 @@
                             <a class="grid-signup d-flex flex-row justify-content-end event-list-item-link w-100"
                                href="{{ event.get_absolute_url }}">
                                 <div class="d-flex flex-column align-items-end justify-content-center">
-                                    <div class="position-relative">
-                                        <span class="fas fa-users"></span>
-                                        {% if event.pending_disposition_count %}
-                                            <span class="pending-indicator"></span>
-                                        {% endif %}
-                                        {{ stats.confirmed_count }}
+                                    <div>
+                                        <span data-bs-toggle="tooltip" data-bs-placement="top"
+                                              title="{% if event|viewable_by %}
+                                                         {% translate "Viewable by" %} {{ event|viewable_by }}.
+                                                     {% else %}
+                                                         {% translate "Event has not been made visible to any groups." %}
+                                                     {% endif %}
+                                                     {% if event.pending_disposition_count %}
+                                                         {% blocktranslate trimmed count waiting=event.pending_disposition_count %}
+                                                             {{ waiting }} participation is awaiting disposition.
+                                                         {% plural %}
+                                                             {{ waiting }} participations are awaiting disposition.
+                                                         {% endblocktranslate %}
+                                                     {% endif %}
+                                                     {% blocktranslate trimmed count confirmed=stats.confirmed_count %}
+                                                         {{ confirmed }} confirmed participation.
+                                                     {% plural %}
+                                                         {{ confirmed }} confirmed participations.
+                                                     {% endblocktranslate %}">
+                                            {% if not event|viewable_by %}
+                                                <i class="fas fa-eye-slash pe-1 text-warning"></i>
+                                            {% endif %}
+                                            {% if event.pending_disposition_count %}
+                                                <i class="fas fa-hourglass-half pe-1 text-warning"></i>
+                                            {% endif %}
+                                            <i class="fas fa-users"></i>
+                                            {{ stats.confirmed_count }}
+                                        </span>
                                     </div>
                                     <div>
                                         {% include "core/fragments/signup_stats_indicator.html" with stats=stats %}

--- a/ephios/core/templates/core/fragments/event_list_list_mode.html
+++ b/ephios/core/templates/core/fragments/event_list_list_mode.html
@@ -66,6 +66,12 @@
                                 </span>
                             </a>
                             <a class="grid-badge event-list-item-link" href="{{ event.get_absolute_url }}">
+                                {% if event.can_change %}
+                                    <small class="pe-1" data-bs-toggle="tooltip" data-bs-placement="left"
+                                           title="{% translate "Responsible" %}">
+                                        <i class="fas fa-crown text-body-secondary"></i>
+                                    </small>
+                                {% endif %}
                                 <span class="badge badge-eventtype eventtype-{{ event.type.pk }}-color">{{ event.type }}</span>
                             </a>
                             <a class="grid-signup d-flex flex-column align-items-end justify-content-center event-list-item-link"

--- a/ephios/core/templatetags/event_extras.py
+++ b/ephios/core/templatetags/event_extras.py
@@ -18,7 +18,6 @@ from ephios.core.signals import (
 from ephios.core.signup.fallback import default_on_exception, get_signup_config_invalid_error
 from ephios.core.views.signup import request_to_participant
 from ephios.extra.colors import get_eventtype_color_style
-from ephios.extra.permissions import get_groups_with_perms
 
 register = template.Library()
 
@@ -189,20 +188,6 @@ def viewable_by(event, allow_db=False):
     For an event from the EventDetailView queryset, return a string of comma-seperated group names
      of groups that are considered to be able to view the event like displayed in the event form.
     """
-    try:
-        names_can_view = {perm.group.name for perm in event.view_permissions}
-        names_can_change = {perm.group.name for perm in event.change_permissions}
-    except AttributeError as exc:
-        if not allow_db:
-            raise ValueError(
-                "Event has no permission attribute. Prefetch them or allow db access in this filter."
-            ) from exc
-        responsible_groups = get_groups_with_perms(
-            event, only_with_perms_in=["change_event"], accept_global_perms=False
-        )
-        names_can_change = {group.name for group in responsible_groups}
-        visible_for = get_groups_with_perms(
-            event, only_with_perms_in=["view_event"], accept_global_perms=False
-        ).exclude(id__in=responsible_groups)
-        names_can_view = {group.name for group in visible_for}
+    names_can_view = {perm.group.name for perm in event.view_permissions}
+    names_can_change = {perm.group.name for perm in event.change_permissions}
     return ", ".join(names_can_view - names_can_change)

--- a/ephios/core/templatetags/event_extras.py
+++ b/ephios/core/templatetags/event_extras.py
@@ -18,6 +18,7 @@ from ephios.core.signals import (
 from ephios.core.signup.fallback import default_on_exception, get_signup_config_invalid_error
 from ephios.core.views.signup import request_to_participant
 from ephios.extra.colors import get_eventtype_color_style
+from ephios.extra.permissions import get_groups_with_perms
 
 register = template.Library()
 
@@ -183,11 +184,25 @@ def can_do_disposition_for(user: UserProfile, shift):
 
 
 @register.filter
-def viewable_by(event):
+def viewable_by(event, allow_db=False):
     """
     For an event from the EventDetailView queryset, return a string of comma-seperated group names
      of groups that are considered to be able to view the event like displayed in the event form.
     """
-    names_can_view = {perm.group.name for perm in event.view_permissions}
-    names_can_change = {perm.group.name for perm in event.change_permissions}
+    try:
+        names_can_view = {perm.group.name for perm in event.view_permissions}
+        names_can_change = {perm.group.name for perm in event.change_permissions}
+    except AttributeError as exc:
+        if not allow_db:
+            raise ValueError(
+                "Event has no permission attribute. Prefetch them or allow db access in this filter."
+            ) from exc
+        responsible_groups = get_groups_with_perms(
+            event, only_with_perms_in=["change_event"], accept_global_perms=False
+        )
+        names_can_change = {group.name for group in responsible_groups}
+        visible_for = get_groups_with_perms(
+            event, only_with_perms_in=["view_event"], accept_global_perms=False
+        ).exclude(id__in=responsible_groups)
+        names_can_view = {group.name for group in visible_for}
     return ", ".join(names_can_view - names_can_change)

--- a/ephios/core/templatetags/event_extras.py
+++ b/ephios/core/templatetags/event_extras.py
@@ -180,3 +180,14 @@ def can_do_disposition_for(user: UserProfile, shift):
         user.has_perm("change_event", shift.event)
         and shift.structure.disposition_participation_form_class is not None
     )
+
+
+@register.filter
+def viewable_by(event):
+    """
+    For an event from the EventDetailView queryset, return a string of comma-seperated group names
+     of groups that are considered to be able to view the event like displayed in the event form.
+    """
+    names_can_view = {perm.group.name for perm in event.view_permissions}
+    names_can_change = {perm.group.name for perm in event.change_permissions}
+    return ", ".join(names_can_view - names_can_change)

--- a/ephios/core/views/event.py
+++ b/ephios/core/views/event.py
@@ -245,11 +245,10 @@ class EventListView(LoginRequiredMixin, ListView):
         qs = qs.prefetch_related(
             Prefetch(
                 "group_object_permission_set",
-                queryset=GroupObjectPermission.objects.filter(permission__codename="view_event"),
+                queryset=GroupObjectPermission.objects.filter(
+                    permission__codename="view_event"
+                ).select_related("group"),
                 to_attr="view_permissions",
-            ),
-            Prefetch(
-                "view_permissions__group",
             ),
         )
         return qs

--- a/ephios/core/views/event.py
+++ b/ephios/core/views/event.py
@@ -484,6 +484,13 @@ class EventDetailView(CustomPermissionRequiredMixin, CanonicalSlugDetailMixin, D
 
     def get_context_data(self, **kwargs):
         kwargs["can_change_event"] = self.request.user.has_perm("core.change_event", self.object)
+        responsible_groups = get_groups_with_perms(
+            self.object, only_with_perms_in=["change_event"], accept_global_perms=False
+        )
+        visible_for = get_groups_with_perms(
+            self.object, only_with_perms_in=["view_event"], accept_global_perms=False
+        ).exclude(id__in=responsible_groups)
+        kwargs["visible_for"] = ", ".join(group.name for group in visible_for)
         return super().get_context_data(**kwargs)
 
 

--- a/ephios/core/views/event.py
+++ b/ephios/core/views/event.py
@@ -250,6 +250,13 @@ class EventListView(LoginRequiredMixin, ListView):
                 ).select_related("group"),
                 to_attr="view_permissions",
             ),
+            Prefetch(
+                "group_object_permission_set",
+                queryset=GroupObjectPermission.objects.filter(
+                    permission__codename="change_event"
+                ).select_related("group"),
+                to_attr="change_permissions",
+            ),
         )
         return qs
 

--- a/ephios/locale/de/LC_MESSAGES/django.po
+++ b/ephios/locale/de/LC_MESSAGES/django.po
@@ -7,8 +7,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-01-03 20:07+0100\n"
-"PO-Revision-Date: 2025-01-03 20:08+0100\n"
+"POT-Creation-Date: 2025-01-05 15:02+0100\n"
+"PO-Revision-Date: 2025-01-05 15:05+0100\n"
 "Last-Translator: Felix Rindt <felix@ephios.de>\n"
 "Language-Team: German <https://hosted.weblate.org/projects/ephios/ephios/de/"
 ">\n"
@@ -50,11 +50,11 @@ msgstr "Token ist zu alt, um angezeigt werden zu können."
 msgid "Token was revoked."
 msgstr "Token wurde entfernt."
 
-#: ephios/api/filters.py:44 ephios/core/models/events.py:292
+#: ephios/api/filters.py:44 ephios/core/models/events.py:298
 msgid "start time"
 msgstr "Beginn"
 
-#: ephios/api/filters.py:45 ephios/core/models/events.py:293
+#: ephios/api/filters.py:45 ephios/core/models/events.py:299
 msgid "end time"
 msgstr "Ende"
 
@@ -69,8 +69,8 @@ msgid "start time less than equals (deprecated, use start_time_before instead)"
 msgstr ""
 "Startzeit kleiner-gleich (deprecated, stattdessen start_time_before nutzen)"
 
-#: ephios/api/filters.py:61 ephios/core/models/events.py:65
-#: ephios/core/models/events.py:77 ephios/core/views/event.py:60
+#: ephios/api/filters.py:61 ephios/core/models/events.py:68
+#: ephios/core/models/events.py:80 ephios/core/views/event.py:61
 msgid "event type"
 msgstr "Veranstaltungstyp"
 
@@ -94,12 +94,12 @@ msgstr "Teilnahme-Typ"
 msgid "Duration in seconds"
 msgstr "Dauer in Sekunden"
 
-#: ephios/api/serializers.py:158 ephios/core/forms/events.py:168
+#: ephios/api/serializers.py:158 ephios/core/forms/events.py:177
 #: ephios/core/templates/core/fragments/shift_box_small.html:24
 msgid "Start time"
 msgstr "Beginn"
 
-#: ephios/api/serializers.py:159 ephios/core/forms/events.py:169
+#: ephios/api/serializers.py:159 ephios/core/forms/events.py:178
 #: ephios/core/templates/core/fragments/shift_box_small.html:25
 msgid "End time"
 msgstr "Ende"
@@ -590,86 +590,97 @@ msgstr ""
 msgid "This account is inactive."
 msgstr "Dieser Account ist deaktiviert."
 
-#: ephios/core/forms/events.py:40 ephios/core/forms/events.py:116
+#: ephios/core/forms/events.py:40 ephios/core/forms/events.py:125
 msgid "Visible for"
 msgstr "Sichtbar für"
 
 #: ephios/core/forms/events.py:42
 msgid ""
 "Select groups which the event shall be visible for. Regardless, the event "
-"will be visible for users that already signed up."
+"will be visible for responsible groups and users that already signed up."
 msgstr ""
 "Wählen Sie Gruppen, für die die Veranstaltung sichtbar sein soll. Unabhängig "
-"davon ist die Veranstaltung für alle Benutzer sichtbar, die sich bereits "
-"angemeldet haben."
+"davon ist die Veranstaltung für alle Verantwortliche und Teilnehmende "
+"sichtbar."
 
-#: ephios/core/forms/events.py:50
+#: ephios/core/forms/events.py:51
 msgid "Responsible persons"
 msgstr "Verantwortliche Personen"
 
-#: ephios/core/forms/events.py:56
+#: ephios/core/forms/events.py:52
+msgid "Individuals can also be made responsible for an event."
+msgstr ""
+"Auch individuelle Personen können für eine Veranstaltung verantwortlich sein."
+
+#: ephios/core/forms/events.py:58
 msgid "Responsible groups"
 msgstr "Verantwortliche Gruppen"
 
-#: ephios/core/forms/events.py:105
+#: ephios/core/forms/events.py:108
 #, python-brace-format
 msgid ""
-"Select groups which the event shall be visible for. This event is also "
-"visible for <b>{groups}</b>, but you don't have the permission to change "
-"visibility for those groups."
+"Also, this event is visible to <b>{groups}</b>, but you don't have "
+"permission to change visibility for those groups."
 msgstr ""
-"Wählen Sie Gruppen, für die die Veranstaltung sichtbar sein soll. Die "
-"Veranstaltung ist außerdem für <b>{groups}</b> sichtbar, aber Sie haben "
+"Außerdem ist die Veranstaltung für <b>{groups}</b> sichtbar, aber Sie haben "
 "keine Berechtigung, die Sichtbarkeit für diese Gruppen zu ändern."
 
 #: ephios/core/forms/events.py:117
+#, python-brace-format
+msgid ""
+"This event is always editable by <b>{groups}</b>, because they manage ephios."
+msgstr ""
+"Die Veranstaltung kann auch von <b>{groups}</b> bearbeitet werden, da diese "
+"ephios verwalten."
+
+#: ephios/core/forms/events.py:126
 msgid "Responsibles"
 msgstr "Verantwortliche"
 
-#: ephios/core/forms/events.py:166 ephios/core/models/users.py:484
+#: ephios/core/forms/events.py:175 ephios/core/models/users.py:484
 #: ephios/core/pdf.py:137 ephios/core/pdf.py:183
 #: ephios/core/templates/core/fragments/shift_box_small.html:22
 #: ephios/core/templates/core/userprofile_workinghours.html:25
-#: ephios/core/views/event.py:68 ephios/core/views/event.py:77
+#: ephios/core/views/event.py:69 ephios/core/views/event.py:78
 #: ephios/core/views/log.py:35
 msgid "Date"
 msgstr "Datum"
 
-#: ephios/core/forms/events.py:167 ephios/core/pdf.py:144
+#: ephios/core/forms/events.py:176 ephios/core/pdf.py:144
 #: ephios/core/pdf.py:194
 #: ephios/core/templates/core/fragments/shift_box_small.html:23
 msgid "Meeting time"
 msgstr "Treffpunkt"
 
-#: ephios/core/forms/events.py:245
+#: ephios/core/forms/events.py:254
 msgid "Meeting time must not be after start time!"
 msgstr "Treffpunkt darf nicht nach dem Beginn liegen!"
 
-#: ephios/core/forms/events.py:276
+#: ephios/core/forms/events.py:285
 msgid "You need to enter a valid color"
 msgstr "Sie müssen eine gültige Farbe eingeben"
 
-#: ephios/core/forms/events.py:309
+#: ephios/core/forms/events.py:318
 msgid "Send notification about new event to everyone"
 msgstr "Alle Benutzer über die neue Veranstaltung benachrichtigen"
 
-#: ephios/core/forms/events.py:310
+#: ephios/core/forms/events.py:319
 msgid "Send reminder to everyone that is not participating"
 msgstr "Alle nicht teilnehmenden Benutzer an die Veranstaltung erinnern"
 
-#: ephios/core/forms/events.py:311
+#: ephios/core/forms/events.py:320
 msgid "Send a message to all participants"
 msgstr "Nachricht an alle Teilnehmenden senden"
 
-#: ephios/core/forms/events.py:316
+#: ephios/core/forms/events.py:325
 msgid "Mail content"
 msgstr "Nachricht"
 
-#: ephios/core/forms/events.py:326
+#: ephios/core/forms/events.py:335
 msgid "Send"
 msgstr "Senden"
 
-#: ephios/core/forms/events.py:336
+#: ephios/core/forms/events.py:345
 msgid "You cannot send an empty mail."
 msgstr "Sie können keine leere Nachricht versenden."
 
@@ -864,32 +875,32 @@ msgstr "Dienst"
 msgid "Training"
 msgstr "Ausbildung"
 
-#: ephios/core/models/events.py:51
+#: ephios/core/models/events.py:52
 msgid "to everyone"
 msgstr "alle Personen"
 
-#: ephios/core/models/events.py:52
+#: ephios/core/models/events.py:53
 msgid "to confirmed participants"
 msgstr "bestätigte Teilnehmende"
 
-#: ephios/core/models/events.py:53
+#: ephios/core/models/events.py:54
 msgid "only to responsible users"
 msgstr "nur verantwortliche Personen"
 
-#: ephios/core/models/events.py:55 ephios/core/models/events.py:74
+#: ephios/core/models/events.py:56 ephios/core/models/events.py:77
 #: ephios/core/models/users.py:247 ephios/core/models/users.py:274
 msgid "title"
 msgstr "Titel"
 
-#: ephios/core/models/events.py:56
+#: ephios/core/models/events.py:57
 msgid "color"
 msgstr "Farbe"
 
-#: ephios/core/models/events.py:58
+#: ephios/core/models/events.py:59
 msgid "show participant data"
 msgstr "Teilnehmendeninformationen sichtbar machen für"
 
-#: ephios/core/models/events.py:59
+#: ephios/core/models/events.py:61
 msgid ""
 "If you restrict who can see participant data, others will only be able to "
 "see that there is a participation, but not from whom."
@@ -897,131 +908,131 @@ msgstr ""
 "Wenn Sie dies einschränken, werden andere nur sehen, dass es eine Teilnahme "
 "gibt, aber nicht von wem."
 
-#: ephios/core/models/events.py:66
+#: ephios/core/models/events.py:69
 msgid "event types"
 msgstr "Veranstaltungstypen"
 
-#: ephios/core/models/events.py:75
+#: ephios/core/models/events.py:78
 msgid "description"
 msgstr "Beschreibung"
 
-#: ephios/core/models/events.py:76
+#: ephios/core/models/events.py:79
 msgid "location"
 msgstr "Ort"
 
-#: ephios/core/models/events.py:78
+#: ephios/core/models/events.py:81
 msgid "active"
 msgstr "aktiv"
 
-#: ephios/core/models/events.py:84 ephios/core/models/events.py:289
+#: ephios/core/models/events.py:90 ephios/core/models/events.py:295
 msgid "event"
 msgstr "Veranstaltung"
 
-#: ephios/core/models/events.py:85
+#: ephios/core/models/events.py:91
 msgid "events"
 msgstr "Veranstaltungen"
 
-#: ephios/core/models/events.py:208
+#: ephios/core/models/events.py:214
 msgid "requested"
 msgstr "angefragt"
 
-#: ephios/core/models/events.py:209 ephios/core/views/event.py:87
+#: ephios/core/models/events.py:215 ephios/core/views/event.py:88
 msgid "confirmed"
 msgstr "bestätigt"
 
-#: ephios/core/models/events.py:210
+#: ephios/core/models/events.py:216
 msgid "declined by user"
 msgstr "abgesagt durch helfende Person"
 
-#: ephios/core/models/events.py:211
+#: ephios/core/models/events.py:217
 msgid "rejected by responsible"
 msgstr "abgelehnt durch verantwortliche Person"
 
-#: ephios/core/models/events.py:212
+#: ephios/core/models/events.py:218
 msgid "getting dispatched"
 msgstr "in Zuteilung"
 
-#: ephios/core/models/events.py:225 ephios/core/models/events.py:313
+#: ephios/core/models/events.py:231 ephios/core/models/events.py:319
 msgid "shift"
 msgstr "Schicht"
 
-#: ephios/core/models/events.py:228
+#: ephios/core/models/events.py:234
 msgid "state"
 msgstr "Status"
 
-#: ephios/core/models/events.py:231
+#: ephios/core/models/events.py:237
 msgid "Data on where this participation lives in the shift structure"
 msgstr "Daten zur Positionierung der Teilnahme in der Schicht-Struktur"
 
-#: ephios/core/models/events.py:237
+#: ephios/core/models/events.py:243
 msgid "individual start time"
 msgstr "Individueller Beginn"
 
-#: ephios/core/models/events.py:238
+#: ephios/core/models/events.py:244
 msgid "individual end time"
 msgstr "Individuelles Ende"
 
-#: ephios/core/models/events.py:241
+#: ephios/core/models/events.py:247
 msgid "Comment"
 msgstr "Kommentar"
 
-#: ephios/core/models/events.py:247
+#: ephios/core/models/events.py:253
 msgid "finished"
 msgstr "abgeschlossen"
 
-#: ephios/core/models/events.py:291
+#: ephios/core/models/events.py:297
 msgid "meeting time"
 msgstr "Treffpunkt"
 
-#: ephios/core/models/events.py:295
+#: ephios/core/models/events.py:301
 msgctxt "shift label"
 msgid "label"
 msgstr "Label"
 
-#: ephios/core/models/events.py:298
+#: ephios/core/models/events.py:304
 msgid "Optional label to help differentiate multiple shifts in an event."
 msgstr ""
 "Optionales Label zur Unterscheidung mehrerer Schichten einer Veranstaltung."
 
-#: ephios/core/models/events.py:300
+#: ephios/core/models/events.py:306
 msgid "signup flow"
 msgstr "Anmeldeverfahren"
 
-#: ephios/core/models/events.py:305
+#: ephios/core/models/events.py:311
 msgid "structure"
 msgstr "Struktur"
 
-#: ephios/core/models/events.py:314
+#: ephios/core/models/events.py:320
 msgid "shifts"
 msgstr "Schichten"
 
-#: ephios/core/models/events.py:431
+#: ephios/core/models/events.py:437
 #: ephios/core/templates/core/fragments/shift_box_small.html:26
 msgid "Signup flow"
 msgstr "Anmeldeverfahren"
 
-#: ephios/core/models/events.py:432
+#: ephios/core/models/events.py:438
 #: ephios/core/templates/core/shift_form.html:46
 msgid "Structure"
 msgstr "Struktur"
 
-#: ephios/core/models/events.py:445
+#: ephios/core/models/events.py:451
 msgid "Participant"
 msgstr "Teilnehmende Person"
 
-#: ephios/core/models/events.py:466
+#: ephios/core/models/events.py:472
 msgid "participation"
 msgstr "Teilnahme"
 
-#: ephios/core/models/events.py:467
+#: ephios/core/models/events.py:473
 msgid "participations"
 msgstr "Teilnahmen"
 
-#: ephios/core/models/events.py:492
+#: ephios/core/models/events.py:498
 msgid "placeholder participation"
 msgstr "Platzhalter-Teilnahme"
 
-#: ephios/core/models/events.py:493
+#: ephios/core/models/events.py:499
 msgid "placeholder participations"
 msgstr "Platzhalter-Teilnahmen"
 
@@ -1157,7 +1168,7 @@ msgstr "fehlgeschlagen"
 msgid "denied"
 msgstr "abgelehnt"
 
-#: ephios/core/models/users.py:401 ephios/core/views/event.py:82
+#: ephios/core/models/users.py:401 ephios/core/views/event.py:83
 msgid "State"
 msgstr "Status"
 
@@ -2004,7 +2015,7 @@ msgid "View edit history"
 msgstr "Änderungsverlauf"
 
 #: ephios/core/templates/core/event_detail.html:113
-#: ephios/core/templates/core/fragments/event_list_list_mode.html:95
+#: ephios/core/templates/core/fragments/event_list_list_mode.html:121
 #: ephios/core/templates/core/mails/new_event.html:18
 #: ephios/core/templates/core/workinghours_list.html:18
 #: ephios/plugins/federation/templates/federation/external_event_list.html:66
@@ -2012,7 +2023,17 @@ msgstr "Änderungsverlauf"
 msgid "to"
 msgstr "bis"
 
-#: ephios/core/templates/core/event_detail.html:138
+#: ephios/core/templates/core/event_detail.html:127
+#: ephios/core/templates/core/fragments/event_list_list_mode.html:80
+msgid "Event has not been made visible to any groups."
+msgstr "Veranstaltung wurde für keine Gruppe sichtbar gemacht."
+
+#: ephios/core/templates/core/event_detail.html:130
+#: ephios/core/templates/core/fragments/event_list_list_mode.html:78
+msgid "Viewable by"
+msgstr "Sichtbar für"
+
+#: ephios/core/templates/core/event_detail.html:149
 msgid "No shifts"
 msgstr "Keine Schichten"
 
@@ -2109,7 +2130,7 @@ msgid "Add %(title)s"
 msgstr "%(title)s hinzufügen"
 
 #: ephios/core/templates/core/fragments/event_list_day_mode.html:52
-#: ephios/core/templates/core/fragments/event_list_list_mode.html:108
+#: ephios/core/templates/core/fragments/event_list_list_mode.html:135
 #: ephios/plugins/federation/templates/federation/external_event_list.html:78
 msgid "No results"
 msgstr "Keine Ergebnisse"
@@ -2117,6 +2138,20 @@ msgstr "Keine Ergebnisse"
 #: ephios/core/templates/core/fragments/event_list_list_mode.html:13
 msgid "Delete selected"
 msgstr "Ausgewählte löschen"
+
+#: ephios/core/templates/core/fragments/event_list_list_mode.html:83
+#, python-format
+msgid "%(waiting)s participation is awaiting disposition."
+msgid_plural "%(waiting)s participations are awaiting disposition."
+msgstr[0] "%(waiting)s Teilnehmende wartet auf Disposition."
+msgstr[1] "%(waiting)s Teilnehmende warten auf Disposition."
+
+#: ephios/core/templates/core/fragments/event_list_list_mode.html:89
+#, python-format
+msgid "%(confirmed)s confirmed participation."
+msgid_plural "%(confirmed)s confirmed participations."
+msgstr[0] "%(confirmed)s bestätigte Teilnehmende"
+msgstr[1] "%(confirmed)s bestätigte Teilnehmende"
 
 #: ephios/core/templates/core/fragments/pending_consequences.html:8
 msgid "Your requests"
@@ -2772,7 +2807,7 @@ msgid "No entries"
 msgstr "Keine Einträge"
 
 #: ephios/core/views/accounts.py:39 ephios/core/views/accounts.py:40
-#: ephios/core/views/event.py:55 ephios/core/views/event.py:56
+#: ephios/core/views/event.py:56 ephios/core/views/event.py:57
 msgid "Search for…"
 msgstr "Suche nach…"
 
@@ -2873,42 +2908,42 @@ msgstr "Es wurden keine Veranstaltungen zum Löschen ausgewählt."
 msgid "The selected events have been deleted."
 msgstr "Die ausgewählten Veranstaltungen wurden gelöscht."
 
-#: ephios/core/views/event.py:71
+#: ephios/core/views/event.py:72
 msgctxt "event date filter"
 msgid "until"
 msgstr "bis zum"
 
-#: ephios/core/views/event.py:72
+#: ephios/core/views/event.py:73
 msgctxt "event date filter"
 msgid "from"
 msgstr "ab dem"
 
-#: ephios/core/views/event.py:85
+#: ephios/core/views/event.py:86
 msgid "all"
 msgstr "alle"
 
-#: ephios/core/views/event.py:86
+#: ephios/core/views/event.py:87
 msgid "no response"
 msgstr "ohne Rückmeldung"
 
-#: ephios/core/views/event.py:88
+#: ephios/core/views/event.py:89
 msgid "requested or confirmed"
 msgstr "angefragt oder bestätigt"
 
-#: ephios/core/views/event.py:89
+#: ephios/core/views/event.py:90
 msgid "disposition to do"
 msgstr "Disposition offen"
 
-#: ephios/core/views/event.py:540 ephios/core/views/shift.py:122
+#: ephios/core/views/event.py:558 ephios/core/views/shift.py:122
 #, python-brace-format
 msgid "The event {title} has been saved."
 msgstr "Die Veranstaltung {title} wurde gespeichert."
 
-#: ephios/core/views/event.py:637
+#: ephios/core/views/event.py:655
 msgid "Event copied successfully."
 msgstr "Veranstaltung erfolgreich kopiert."
 
-#: ephios/core/views/event.py:670
+#: ephios/core/views/event.py:688
 msgid "Notifications sent succesfully."
 msgstr "Benachrichtigungen erfolgreich gesendet."
 

--- a/ephios/static/ephios/scss/ephios_custom.scss
+++ b/ephios/static/ephios/scss/ephios_custom.scss
@@ -157,7 +157,7 @@ footer {
 
   @media (min-width: 992px) {
     .grid-wrapper {
-      grid-template-columns: 6fr auto 8rem 7rem 0px;
+      grid-template-columns: 6fr auto 8rem 5rem 0;
       grid-template-rows: auto;
       grid-template-areas:
         "title badge time signup action"

--- a/ephios/static/ephios/scss/ephios_custom.scss
+++ b/ephios/static/ephios/scss/ephios_custom.scss
@@ -157,7 +157,7 @@ footer {
 
   @media (min-width: 992px) {
     .grid-wrapper {
-      grid-template-columns: 6fr auto 8rem 5rem 0;
+      grid-template-columns: 6fr auto 8rem 6rem 0;
       grid-template-rows: auto;
       grid-template-areas:
         "title badge time signup action"
@@ -174,20 +174,6 @@ This hack fixes that. Inspired by https://github.com/select2/select2/issues/4220
 */
 .select2 {
   width: 100% !important;
-}
-
-//Pending indicator
-.pending-indicator {
-  position: absolute;
-  top: 15px;
-  left: -5px;
-  display: block;
-  width: 10px;
-  height: 10px;
-  color: #ffffff;
-  background-image: linear-gradient($yellow-400, $yellow-500);
-  background-clip: padding-box;
-  border-radius: 50%;
 }
 
 // Indicate participations of minors with a warning right border, though explanation must be available

--- a/ephios/static/ephios/scss/ephios_custom.scss
+++ b/ephios/static/ephios/scss/ephios_custom.scss
@@ -148,7 +148,6 @@ footer {
     grid-area: signup;
     justify-self: end;
     align-self: end;
-    width: 100%;
   }
 
   .grid-action {
@@ -158,7 +157,7 @@ footer {
 
   @media (min-width: 992px) {
     .grid-wrapper {
-      grid-template-columns: 6fr auto 8rem 5rem auto;
+      grid-template-columns: 6fr auto 8rem 7rem 0px;
       grid-template-rows: auto;
       grid-template-areas:
         "title badge time signup action"

--- a/ephios/static/ephios/scss/ephios_custom.scss
+++ b/ephios/static/ephios/scss/ephios_custom.scss
@@ -37,7 +37,7 @@ footer {
 }
 
 .event-list-status-icon {
-  min-width: 28px;
+  min-width: 36px;
 }
 
 .tooltip-inner {


### PR DESCRIPTION
when testing the bulk actions, it was helpful to have some kind of indicator in the event list list to see what events I am responsible for.
This is what I came up with in a few minutes of tinkering with it.

![image](https://github.com/user-attachments/assets/76c74d7d-d1b9-4ef6-8d00-9263cbcd5257)

closes #1258
closes #874
