### PR TITLE
explicitly declare sphinx config file

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -3,8 +3,10 @@ version: 2
 build:
   os: ubuntu-22.04
   tools:
-    python: "3.11"
-
+    python: "3.12"
+sphinx:
+  configuration: docs/conf.py
+formats: all
 python:
   install:
     - method: pip


### PR DESCRIPTION
as explained in https://about.readthedocs.com/blog/2024/12/deprecate-config-files-without-sphinx-or-mkdocs-config/