### PR TITLE
Prefetch participations for day mode of event list

### DIFF
--- a/ephios/core/views/event.py
+++ b/ephios/core/views/event.py
@@ -377,6 +377,16 @@ class EventListView(LoginRequiredMixin, ListView):
             .prefetch_related(Prefetch("shifts", queryset=Shift.objects.order_by("start_time")))
         )
 
+        if (participant := request_to_participant(self.request)) is not None:
+            events = events.prefetch_related(
+                Prefetch(
+                    "shifts__participations",
+                    queryset=AbstractParticipation.objects.all().with_show_participant_data_to(
+                        participant=participant
+                    ),
+                )
+            )
+
         css_context = self._build_day_css_context(events, shifts)
         ctx.update(
             {


### PR DESCRIPTION
`with_show_participant_data_to()` was not applied to the shift participations for the day mode of the event list, thus all participations were redacted.

Fixes #1523