### PR TITLE
upgrade django-guardian to 3.0

### DIFF
--- a/ephios/core/models/events.py
+++ b/ephios/core/models/events.py
@@ -27,7 +27,8 @@ from django.utils.timezone import localtime
 from django.utils.translation import gettext_lazy as _
 from django.utils.translation import pgettext
 from dynamic_preferences.models import PerInstancePreferenceModel
-from guardian.shortcuts import GroupObjectPermission, assign_perm, get_objects_for_user
+from guardian.models import GroupObjectPermission
+from guardian.shortcuts import assign_perm, get_objects_for_user
 from polymorphic.managers import PolymorphicManager
 from polymorphic.models import PolymorphicModel
 from polymorphic.query import PolymorphicQuerySet

--- a/ephios/settings.py
+++ b/ephios/settings.py
@@ -347,7 +347,6 @@ def GET_USERCONTENT_QUOTA():
 
 # Guardian configuration
 ANONYMOUS_USER_NAME = None
-GUARDIAN_MONKEY_PATCH = False
 
 # django-select2
 # Prevent django-select from loading the select2 resources as we want to serve them locally

--- a/poetry.lock
+++ b/poetry.lock
@@ -1060,18 +1060,18 @@ django-jquery-js = "*"
 
 [[package]]
 name = "django-guardian"
-version = "2.4.0"
-description = "Implementation of per object permissions for Django."
+version = "3.0.0"
+description = "Per object permissions for Django"
 optional = false
-python-versions = ">=3.5"
+python-versions = ">=3.9"
 groups = ["main"]
 files = [
-    {file = "django-guardian-2.4.0.tar.gz", hash = "sha256:c58a68ae76922d33e6bdc0e69af1892097838de56e93e78a8361090bcd9f89a0"},
-    {file = "django_guardian-2.4.0-py3-none-any.whl", hash = "sha256:440ca61358427e575323648b25f8384739e54c38b3d655c81d75e0cd0d61b697"},
+    {file = "django_guardian-3.0.0-py3-none-any.whl", hash = "sha256:f3ebe3cc7f486e267041b780c3429ad5db72c909df40c2f74adb1b059582a3cd"},
+    {file = "django_guardian-3.0.0.tar.gz", hash = "sha256:0c79d55c4af2cfc14fbd19539846a1ebfed2a38198b7697e0f5177b7f654e1cd"},
 ]
 
 [package.dependencies]
-Django = ">=2.2"
+django = ">=3.2"
 
 [[package]]
 name = "django-ical"
@@ -4016,4 +4016,4 @@ redis = ["redis"]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.10"
-content-hash = "1b078dddc0d8ec84e1196a8eabab1ae41958b9929c0c09bc3b788d1b3a8a6df3"
+content-hash = "9a419b82a2b7b4c2a0743dfccc983605c14fac5a17c629528e2ca745755b4a77"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ documentation = "https://docs.ephios.de/en/stable/"
 python = "^3.10"
 Django = {version = "~5.2", extras = ["argon2"]}
 django-environ = ">=0.11.2,<0.13"
-django-guardian = "^2.4.0"
+django-guardian = "^3.0.0"
 django-ical = "^1.8.3"
 django-polymorphic = ">=4.1,<5.0"
 django-select2 = ">=8.0,<9.0"

--- a/tests/core/test_views_auth.py
+++ b/tests/core/test_views_auth.py
@@ -1,6 +1,6 @@
 from django.contrib.auth.mixins import AccessMixin
 from django.urls import get_resolver, reverse
-from guardian.mixins import LoginRequiredMixin
+from guardian.mixins import LoginRequiredMixin as GuardianLoginRequiredMixin
 
 
 def test_accounts_login(django_app):
@@ -60,7 +60,7 @@ def _check_view_is_secured(view_func):
     except AttributeError:
         pass
     else:
-        if issubclass(view_class, (AccessMixin, LoginRequiredMixin)):
+        if issubclass(view_class, (AccessMixin, GuardianLoginRequiredMixin)):
             # using an AccessMixin or LoginRequired from Guardian
             return True
     try:


### PR DESCRIPTION
As the update is mostly considered a drop-in replacement (with some changes in how settings are configured), There wasn't really any code I could remove:

- we still need our own PermissionRequiredMixin, as the guardian one didn't add the possibility for redirecting anonymous users to login while raising 403 for authenticated users on lack of permission
- Looks like there will be some new functionality in 3.1: https://github.com/django-guardian/django-guardian/pull/855