### PR TITLE
colorful own participation pills

### DIFF
--- a/ephios/plugins/baseshiftstructures/templates/baseshiftstructures/participation_card_inline.html
+++ b/ephios/plugins/baseshiftstructures/templates/baseshiftstructures/participation_card_inline.html
@@ -42,7 +42,11 @@
 
 
 <a class="badge badge-participant
-          {% if participation.state == participation.States.CONFIRMED %}bg-secondary text-dark{% else %}bg-light text-body-secondary{% endif %}
+          {% if participation == own_participation %}
+              {% if participation.state == participation.States.CONFIRMED %}text-bg-success{% else %}text-bg-warning{% endif %}
+          {% else %}
+              {% if participation.state == participation.States.CONFIRMED %}text-bg-secondary text-dark{% else %}text-bg-light text-body-secondary{% endif %}
+          {% endif %}
           {% if participation.participant.is_minor %}participation-card-minor{% endif %}
          "
    tabindex="0"


### PR DESCRIPTION
Could help find users their own participation at a glance. Could use other ways of course, I just looked at styling options in [the bootstrap docs](https://getbootstrap.com/docs/5.3/components/badge/)...

<img width="972" height="527" alt="image" src="https://github.com/user-attachments/assets/726d600c-01b3-4a79-82af-a0d2b5c1b731" />
