### PR TITLE
underscore should alwasy be gettext_lazy

### DIFF
--- a/ephios/core/calendar.py
+++ b/ephios/core/calendar.py
@@ -4,7 +4,7 @@ from itertools import groupby
 
 from django.template.loader import render_to_string
 from django.utils.formats import date_format
-from django.utils.translation import gettext as _
+from django.utils.translation import gettext_lazy as _
 
 
 class ShiftCalendar(HTMLCalendar):

--- a/ephios/core/forms/events.py
+++ b/ephios/core/forms/events.py
@@ -14,7 +14,7 @@ from django.db.models import Q
 from django.forms import ColorInput
 from django.forms.utils import from_current_timezone
 from django.utils.timezone import make_aware
-from django.utils.translation import gettext as _
+from django.utils.translation import gettext_lazy as _
 from django_select2.forms import Select2MultipleWidget
 from dynamic_preferences.forms import PreferenceForm
 from guardian.shortcuts import assign_perm, get_objects_for_user, get_users_with_perms, remove_perm

--- a/ephios/core/forms/users.py
+++ b/ephios/core/forms/users.py
@@ -15,7 +15,7 @@ from django.forms import (
     inlineformset_factory,
 )
 from django.urls import reverse
-from django.utils.translation import gettext as _
+from django.utils.translation import gettext_lazy as _
 from django_select2.forms import Select2MultipleWidget, Select2Widget
 from guardian.shortcuts import assign_perm, get_objects_for_group, remove_perm
 

--- a/ephios/core/management/commands/devdata.py
+++ b/ephios/core/management/commands/devdata.py
@@ -4,7 +4,7 @@ from django.contrib.auth.hashers import make_password
 from django.core.management.base import BaseCommand
 from django.db import transaction
 from django.utils.timezone import make_aware
-from django.utils.translation import gettext as _
+from django.utils.translation import gettext
 from guardian.shortcuts import assign_perm
 
 from ephios.core.models import Event, EventType, Shift, UserProfile
@@ -23,15 +23,15 @@ def create_objects():
 
     from django.contrib.auth.models import Group
 
-    volunteers = Group.objects.create(name=_("Volunteers"))
+    volunteers = Group.objects.create(name=gettext("Volunteers"))
     volunteers.user_set.add(admin_user)
     volunteers.save()
 
-    planners = Group.objects.create(name=_("Planners"))
+    planners = Group.objects.create(name=gettext("Planners"))
     planners.user_set.add(admin_user)
     planners.save()
 
-    managers = Group.objects.create(name=_("Managers"))
+    managers = Group.objects.create(name=gettext("Managers"))
     managers.user_set.add(admin_user)
     managers.save()
 
@@ -47,8 +47,8 @@ def create_objects():
     assign_perm("auth.change_group", managers)
     assign_perm("auth.delete_group", managers)
 
-    service_type = EventType.objects.create(title=_("Service"))
-    EventType.objects.create(title=_("Training"))
+    service_type = EventType.objects.create(title=gettext("Service"))
+    EventType.objects.create(title=gettext("Training"))
 
     user = UserProfile(
         email="user@localhost",

--- a/ephios/core/pdf.py
+++ b/ephios/core/pdf.py
@@ -3,7 +3,7 @@ import io
 from django.http import FileResponse
 from django.utils import formats
 from django.utils.timezone import get_default_timezone
-from django.utils.translation import gettext as _
+from django.utils.translation import gettext_lazy as _
 from django.views import View
 from django.views.generic.detail import SingleObjectMixin
 from reportlab.lib import colors

--- a/ephios/core/services/password_reset.py
+++ b/ephios/core/services/password_reset.py
@@ -3,7 +3,7 @@ import logging
 from django.contrib.auth.password_validation import MinimumLengthValidator
 from django.core.mail import EmailMultiAlternatives
 from django.template.loader import render_to_string
-from django.utils.translation import gettext as _
+from django.utils.translation import gettext_lazy as _
 from dynamic_preferences.registries import global_preferences_registry
 
 from ephios.core.dynamic import dynamic_settings

--- a/ephios/core/views/accounts.py
+++ b/ephios/core/views/accounts.py
@@ -7,7 +7,7 @@ from django.db.models import Count, Exists, OuterRef, Prefetch, Q, QuerySet
 from django.shortcuts import redirect
 from django.urls import reverse
 from django.utils.functional import cached_property
-from django.utils.translation import gettext as _
+from django.utils.translation import gettext_lazy as _
 from django.views.generic import CreateView, DeleteView, ListView, TemplateView, UpdateView
 from django.views.generic.detail import SingleObjectMixin
 from django_select2.forms import ModelSelect2Widget, Select2Widget

--- a/ephios/core/views/auth.py
+++ b/ephios/core/views/auth.py
@@ -9,7 +9,7 @@ from django.db.models import QuerySet
 from django.shortcuts import get_object_or_404, redirect
 from django.template.defaultfilters import urlencode
 from django.urls import reverse, reverse_lazy
-from django.utils.translation import gettext as _
+from django.utils.translation import gettext_lazy as _
 from django.views.generic import (
     CreateView,
     DeleteView,

--- a/ephios/core/views/bulk.py
+++ b/ephios/core/views/bulk.py
@@ -1,7 +1,7 @@
 from django.contrib import messages
 from django.shortcuts import redirect
 from django.urls import reverse
-from django.utils.translation import gettext as _
+from django.utils.translation import gettext_lazy as _
 from django.views import View
 from django.views.generic.base import TemplateResponseMixin
 from guardian.shortcuts import get_objects_for_user

--- a/ephios/core/views/event.py
+++ b/ephios/core/views/event.py
@@ -16,7 +16,7 @@ from django.utils.datastructures import MultiValueDict
 from django.utils.functional import cached_property
 from django.utils.safestring import mark_safe
 from django.utils.timezone import get_current_timezone, make_aware
-from django.utils.translation import gettext as _
+from django.utils.translation import gettext_lazy as _
 from django.utils.translation import pgettext_lazy
 from django.views import View
 from django.views.generic import (

--- a/ephios/core/views/eventtype.py
+++ b/ephios/core/views/eventtype.py
@@ -2,7 +2,7 @@ from django.contrib import messages
 from django.contrib.messages.views import SuccessMessageMixin
 from django.shortcuts import redirect
 from django.urls import reverse
-from django.utils.translation import gettext as _
+from django.utils.translation import gettext_lazy as _
 from django.views.generic import CreateView, DeleteView, ListView, TemplateView
 from django.views.generic.detail import SingleObjectMixin
 from dynamic_preferences.forms import preference_form_builder

--- a/ephios/core/views/settings.py
+++ b/ephios/core/views/settings.py
@@ -8,7 +8,7 @@ from django.contrib.auth.mixins import LoginRequiredMixin
 from django.contrib.auth.views import PasswordChangeView
 from django.contrib.messages.views import SuccessMessageMixin
 from django.urls import reverse, reverse_lazy
-from django.utils.translation import gettext as _
+from django.utils.translation import gettext_lazy as _
 from django.utils.translation import pgettext_lazy
 from django.views.generic import FormView
 from django.views.generic.edit import UpdateView

--- a/ephios/core/views/shift.py
+++ b/ephios/core/views/shift.py
@@ -8,7 +8,7 @@ from django.urls import reverse
 from django.utils import timezone
 from django.utils.datastructures import MultiValueDictKeyError
 from django.utils.timezone import get_default_timezone
-from django.utils.translation import gettext as _
+from django.utils.translation import gettext_lazy as _
 from django.views import View
 from django.views.generic import DeleteView, FormView, TemplateView
 from django.views.generic.detail import SingleObjectMixin

--- a/ephios/core/views/workinghour.py
+++ b/ephios/core/views/workinghour.py
@@ -13,7 +13,7 @@ from django.db.models import DurationField, ExpressionWrapper, F, Sum
 from django.shortcuts import get_object_or_404, redirect
 from django.urls import reverse
 from django.utils.functional import cached_property
-from django.utils.translation import gettext as _
+from django.utils.translation import gettext_lazy as _
 from django.views.generic import DeleteView, DetailView, FormView, TemplateView, UpdateView
 from django_select2.forms import Select2Widget
 from guardian.shortcuts import get_objects_for_user

--- a/ephios/extra/bootstrap.py
+++ b/ephios/extra/bootstrap.py
@@ -1,5 +1,5 @@
 from django.utils.safestring import mark_safe
-from django.utils.translation import gettext as _
+from django.utils.translation import gettext_lazy as _
 
 
 def render_alert(content, alert_type=None, dismissible=True):

--- a/ephios/extra/widgets.py
+++ b/ephios/extra/widgets.py
@@ -3,7 +3,7 @@ from django import forms
 from django.core.exceptions import ValidationError
 from django.forms import CharField, DateInput, MultiWidget, Textarea, TimeInput
 from django.forms.utils import to_current_timezone
-from django.utils.translation import gettext as _
+from django.utils.translation import gettext_lazy as _
 
 
 class CustomDateInput(DateInput):

--- a/ephios/plugins/federation/forms.py
+++ b/ephios/plugins/federation/forms.py
@@ -7,7 +7,7 @@ from urllib.parse import urlparse
 from django import forms
 from django.core.exceptions import ValidationError
 from django.forms import CheckboxSelectMultiple
-from django.utils.translation import gettext as _
+from django.utils.translation import gettext_lazy as _
 
 from ephios.core.dynamic import dynamic_settings
 from ephios.core.forms.events import BasePluginFormMixin

--- a/ephios/plugins/files/forms.py
+++ b/ephios/plugins/files/forms.py
@@ -2,7 +2,7 @@ from django.conf import settings
 from django.core.exceptions import ValidationError
 from django.forms import FileInput, Form, ModelForm, ModelMultipleChoiceField
 from django.template.defaultfilters import filesizeformat
-from django.utils.translation import gettext as _
+from django.utils.translation import gettext_lazy as _
 from django_select2.forms import Select2MultipleWidget
 
 from ephios.core.forms.events import BasePluginFormMixin

--- a/ephios/plugins/files/signals.py
+++ b/ephios/plugins/files/signals.py
@@ -1,7 +1,7 @@
 from django.dispatch import receiver
 from django.template.loader import render_to_string
 from django.urls import reverse_lazy
-from django.utils.translation import gettext as _
+from django.utils.translation import gettext_lazy as _
 
 from ephios.core.signals import (
     HTML_EVENT_INFO,

--- a/ephios/plugins/pages/signals.py
+++ b/ephios/plugins/pages/signals.py
@@ -1,6 +1,6 @@
 from django.dispatch import receiver
 from django.urls import reverse
-from django.utils.translation import gettext as _
+from django.utils.translation import gettext_lazy as _
 
 from ephios.core.signals import footer_link, register_group_permission_fields, settings_sections
 from ephios.core.views.settings import SETTINGS_MANAGEMENT_SECTION_KEY

--- a/ephios/plugins/pages/views.py
+++ b/ephios/plugins/pages/views.py
@@ -1,7 +1,7 @@
 from django.contrib import messages
 from django.contrib.auth.views import redirect_to_login
 from django.urls import reverse
-from django.utils.translation import gettext as _
+from django.utils.translation import gettext_lazy as _
 from django.views.generic import CreateView, DeleteView, DetailView, ListView, UpdateView
 
 from ephios.extra.auth import access_exempt

--- a/ephios/plugins/qualification_management/signals.py
+++ b/ephios/plugins/qualification_management/signals.py
@@ -1,6 +1,6 @@
 from django.dispatch import receiver
 from django.urls import reverse
-from django.utils.translation import gettext as _
+from django.utils.translation import gettext_lazy as _
 
 from ephios.core.signals import settings_sections
 from ephios.core.views.settings import SETTINGS_MANAGEMENT_SECTION_KEY

--- a/ephios/plugins/simpleresource/forms.py
+++ b/ephios/plugins/simpleresource/forms.py
@@ -1,6 +1,6 @@
 from django.forms import BaseModelFormSet, BooleanField, ModelForm, modelformset_factory
 from django.forms.formsets import DELETION_FIELD_NAME
-from django.utils.translation import gettext as _
+from django.utils.translation import gettext_lazy as _
 from django_select2.forms import Select2MultipleWidget
 
 from ephios.core.forms.events import BasePluginFormMixin


### PR DESCRIPTION
If it's not lazy, strings specified in class attributes (like success_message on CBVs) are always translated in the default locale (de). `_` should always be the lazy variant to avoid confusion. In placed were it must not be lazy, use an explicit `gettext` instead. I used search to replace occurrences for the wrong import.