### PR TITLE
allow users to customize confirmed participations

### DIFF
--- a/src/ephios/core/signup/flow/participant_validation.py
+++ b/src/ephios/core/signup/flow/participant_validation.py
@@ -197,10 +197,7 @@ class BaseSignupActionValidator:
             self.participation is not None and self.participation.is_in_positive_state()
         )
 
-        if positive_state:
-            # If in a positive state, check that you can decline and then sign up again.
-            return self.can_decline() and not self.get_signup_errors()
-        return not self.get_signup_errors()
+        return positive_state or not self.get_signup_errors()
 
 
 class BasicSignupActionValidator(BaseSignupActionValidator):

--- a/src/ephios/core/signup/forms.py
+++ b/src/ephios/core/signup/forms.py
@@ -182,14 +182,19 @@ class SignupForm(BaseParticipationForm):
             FormActions(*self._get_buttons()),
         )
 
+        validator = self.instance and self.shift.signup_flow.get_validator(
+            self.instance.participant
+        )
+        can_customize_times = (
+            validator
+            and (not self.instance.is_in_positive_state() or validator.can_decline())
+            and not validator.get_signup_errors()
+        )
         if (
             not getattr(
                 self.shift.signup_flow.configuration, "user_can_customize_signup_times", False
             )
-        ) or (
-            self.instance
-            and self.shift.signup_flow.get_validator(self.instance.participant).get_signup_errors()
-        ):
+        ) or not can_customize_times:
             self.fields["individual_start_time"].disabled = True
             self.fields["individual_end_time"].disabled = True
 

--- a/src/ephios/core/signup/forms.py
+++ b/src/ephios/core/signup/forms.py
@@ -186,7 +186,10 @@ class SignupForm(BaseParticipationForm):
             not getattr(
                 self.shift.signup_flow.configuration, "user_can_customize_signup_times", False
             )
-        ) or (self.instance and self.instance.state == AbstractParticipation.States.CONFIRMED):
+        ) or (
+            self.instance
+            and self.shift.signup_flow.get_validator(self.instance.participant).get_signup_errors()
+        ):
             self.fields["individual_start_time"].disabled = True
             self.fields["individual_end_time"].disabled = True
 

--- a/src/ephios/core/signup/forms.py
+++ b/src/ephios/core/signup/forms.py
@@ -182,9 +182,11 @@ class SignupForm(BaseParticipationForm):
             FormActions(*self._get_buttons()),
         )
 
-        if not getattr(
-            self.shift.signup_flow.configuration, "user_can_customize_signup_times", False
-        ):
+        if (
+            not getattr(
+                self.shift.signup_flow.configuration, "user_can_customize_signup_times", False
+            )
+        ) or (self.instance and self.instance.state == AbstractParticipation.States.CONFIRMED):
             self.fields["individual_start_time"].disabled = True
             self.fields["individual_end_time"].disabled = True
 


### PR DESCRIPTION
closes #1599

keeping the behaviour that users can customize times if they are confirmed and can decline and re-signup. we could also think about dropping this (related to #620)
